### PR TITLE
add optional permissions parameter to store secrets utils

### DIFF
--- a/examples/common/utils.py
+++ b/examples/common/utils.py
@@ -91,6 +91,7 @@ async def store_secret_array(
     secret_array: np.ndarray,
     name: str,
     nada_type: Any,
+    permissions: nillion.Permissions = None,
 ):
     """
     Asynchronous function to store secret arrays on the nillion client.
@@ -104,6 +105,8 @@ async def store_secret_array(
         secret_array (np.ndarray): Secret array.
         name (str): Secrets name.
         nada_type (Any): Nada type.
+        permissions: nillion.Permissions: Optional Permissions.
+        
 
     Returns:
         str: Store ID.
@@ -117,6 +120,7 @@ async def store_secret_array(
         party_id,
         party_name,
         secrets,
+        permissions,
     )
     return store_id
 
@@ -130,6 +134,8 @@ async def store_secret_value(
     secret_value: Any,
     name: str,
     nada_type: Any,
+    permissions: nillion.Permissions = None,
+    
 ):
     """
     Asynchronous function to store secret values on the nillion client.
@@ -143,6 +149,7 @@ async def store_secret_value(
         secret_value (Any): Secret single value.
         name (str): Secrets name.
         nada_type (Any): Nada type.
+        permissions: nillion.Permissions: Optional Permissions.
 
     Returns:
         str: Store ID.
@@ -162,6 +169,7 @@ async def store_secret_value(
         party_id,
         party_name,
         secrets,
+        permissions,
     )
     return store_id
 
@@ -173,6 +181,7 @@ async def store_secrets(
     party_id: str,
     party_name: str,
     secrets: nillion.Secrets,
+    permissions: nillion.Permissions = None
 ):
     """
     Asynchronous function to store secret values on the nillion client.
@@ -184,13 +193,14 @@ async def store_secrets(
         party_id (str): Party ID.
         party_name (str): Party name.
         secrets (nillion.Secrets): Secrets.
+        permissions: nillion.Permissions: Optional Permissions.
 
     Returns:
         str: Store ID.
     """
     secret_bindings = nillion.ProgramBindings(program_id)
     secret_bindings.add_input_party(party_name, party_id)
-    store_id = await client.store_secrets(cluster_id, secret_bindings, secrets, None)
+    store_id = await client.store_secrets(cluster_id, secret_bindings, secrets, permissions)
     return store_id
 
 

--- a/examples/common/utils.py
+++ b/examples/common/utils.py
@@ -105,7 +105,7 @@ async def store_secret_array(
         secret_array (np.ndarray): Secret array.
         name (str): Secrets name.
         nada_type (Any): Nada type.
-        permissions: nillion.Permissions: Optional Permissions.
+        permissions (nillion.Permissions): Optional Permissions.
         
 
     Returns:
@@ -149,7 +149,7 @@ async def store_secret_value(
         secret_value (Any): Secret single value.
         name (str): Secrets name.
         nada_type (Any): Nada type.
-        permissions: nillion.Permissions: Optional Permissions.
+        permissions (nillion.Permissions): Optional Permissions.
 
     Returns:
         str: Store ID.
@@ -193,7 +193,7 @@ async def store_secrets(
         party_id (str): Party ID.
         party_name (str): Party name.
         secrets (nillion.Secrets): Secrets.
-        permissions: nillion.Permissions: Optional Permissions.
+        permissions (nillion.Permissions): Optional Permissions.
 
     Returns:
         str: Store ID.


### PR DESCRIPTION
For multi-party compute, permissions are needed to give the compute party permissions to use other parties' secrets in the programs. I update the store_secrets helpers to accept an optional permissions param. If it's not passed in, permissions default to None.

Tested in my linear regression use case: https://github.com/oceans404/nada-linear-regression-housing/blob/main/main.py#L81-L86