### PR TITLE
Chore: Update version 0.5.0

### DIFF
--- a/examples/complex_model/main.py
+++ b/examples/complex_model/main.py
@@ -12,15 +12,16 @@ import nada_numpy.client as na_client
 import numpy as np
 import py_nillion_client as nillion
 import torch
+from common.utils import compute, store_program, store_secrets
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
 from dotenv import load_dotenv
-from nada_ai.client import TorchClient
-from nillion_python_helpers import create_nillion_client, create_payments_config
+from nillion_python_helpers import (create_nillion_client,
+                                    create_payments_config)
 from py_nillion_client import NodeKey, UserKey
 
-from common.utils import compute, store_program, store_secrets
+from nada_ai.client import TorchClient
 
 home = os.getenv("HOME")
 load_dotenv(f"{home}/.config/nillion/nillion-devnet.env")

--- a/examples/complex_model/src/my_model.py
+++ b/examples/complex_model/src/my_model.py
@@ -1,4 +1,5 @@
 import nada_numpy as na
+
 from nada_ai import nn
 
 

--- a/examples/complex_model/tests/complex_model.yaml
+++ b/examples/complex_model/tests/complex_model.yaml
@@ -1,151 +1,77 @@
 program: complex_model
 inputs:
-  my_input_2_1_0:
-    SecretInteger: '163840'
-  my_input_2_2_0:
-    SecretInteger: '163840'
-  my_input_0_0_2:
-    SecretInteger: '163840'
-  my_model_linear.bias_0:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_0_0_0:
-    SecretInteger: '163840'
-  my_model_linear.weight_1_1:
-    SecretInteger: '163840'
-  my_input_0_1_2:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_1_1_0:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_2_0_1:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_0_1_0:
-    SecretInteger: '163840'
-  my_input_2_1_1:
-    SecretInteger: '163840'
-  my_input_1_1_2:
-    SecretInteger: '163840'
-  my_input_2_1_2:
-    SecretInteger: '163840'
-  my_input_1_2_2:
-    SecretInteger: '163840'
-  my_input_2_3_0:
-    SecretInteger: '163840'
-  my_input_0_2_0:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_2_0_1:
-    SecretInteger: '163840'
-  my_input_1_1_1:
-    SecretInteger: '163840'
-  my_input_2_2_1:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_1_0_0:
-    SecretInteger: '163840'
-  my_input_0_2_1:
-    SecretInteger: '163840'
-  my_input_0_0_1:
-    SecretInteger: '163840'
-  my_model_linear.weight_1_2:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_1_0_1:
-    SecretInteger: '163840'
-  my_model_linear.weight_1_3:
-    SecretInteger: '163840'
-  my_input_0_0_0:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_0_1_1:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.bias_1:
-    SecretInteger: '163840'
-  my_input_1_1_0:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_2_1_0:
-    SecretInteger: '163840'
-  my_input_1_3_0:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.bias_0:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_1_1_1:
-    SecretInteger: '163840'
-  my_input_0_3_1:
-    SecretInteger: '163840'
-  my_input_2_0_0:
-    SecretInteger: '163840'
-  my_input_2_2_2:
-    SecretInteger: '163840'
-  my_model_linear.weight_0_0:
-    SecretInteger: '163840'
-  my_model_linear.weight_0_3:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_2_1_1:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_0_0_1:
-    SecretInteger: '163840'
-  my_model_linear.weight_0_1:
-    SecretInteger: '163840'
-  my_input_2_3_1:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_1_1_1:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_0_1_0:
-    SecretInteger: '163840'
-  my_input_2_0_1:
-    SecretInteger: '163840'
-  my_input_1_3_2:
-    SecretInteger: '163840'
-  my_input_1_0_1:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_0_0_1:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_1_0_0:
-    SecretInteger: '163840'
-  my_model_linear.weight_1_0:
-    SecretInteger: '163840'
-  my_input_2_0_2:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_2_0_0:
-    SecretInteger: '163840'
-  my_input_1_0_2:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_0_0_0:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_2_1_1:
-    SecretInteger: '163840'
-  my_input_0_2_2:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_2_0_0:
-    SecretInteger: '163840'
-  my_model_linear.bias_1:
-    SecretInteger: '163840'
-  my_input_1_0_0:
-    SecretInteger: '163840'
-  my_input_0_3_2:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_0_1_1:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_1_1_1_0:
-    SecretInteger: '163840'
-  my_input_1_2_0:
-    SecretInteger: '163840'
-  my_input_0_1_1:
-    SecretInteger: '163840'
-  my_input_0_3_0:
-    SecretInteger: '163840'
-  my_model_linear.weight_0_2:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_2_1_0:
-    SecretInteger: '163840'
-  my_model_conv_module.conv.weight_0_1_0_1:
-    SecretInteger: '163840'
-  my_input_1_2_1:
-    SecretInteger: '163840'
-  my_input_1_3_1:
-    SecretInteger: '163840'
-  my_input_0_1_0:
-    SecretInteger: '163840'
-  my_input_2_3_2:
-    SecretInteger: '163840'
+  my_input_2_1_0: 163840
+  my_input_2_2_0: 163840
+  my_input_0_0_2: 163840
+  my_model_linear.bias_0: 163840
+  my_model_conv_module.conv.weight_1_0_0_0: 163840
+  my_model_linear.weight_1_1: 163840
+  my_input_0_1_2: 163840
+  my_model_conv_module.conv.weight_0_1_1_0: 163840
+  my_model_conv_module.conv.weight_0_2_0_1: 163840
+  my_model_conv_module.conv.weight_1_0_1_0: 163840
+  my_input_2_1_1: 163840
+  my_input_1_1_2: 163840
+  my_input_2_1_2: 163840
+  my_input_1_2_2: 163840
+  my_input_2_3_0: 163840
+  my_input_0_2_0: 163840
+  my_model_conv_module.conv.weight_1_2_0_1: 163840
+  my_input_1_1_1: 163840
+  my_input_2_2_1: 163840
+  my_model_conv_module.conv.weight_0_1_0_0: 163840
+  my_input_0_2_1: 163840
+  my_input_0_0_1: 163840
+  my_model_linear.weight_1_2: 163840
+  my_model_conv_module.conv.weight_1_1_0_1: 163840
+  my_model_linear.weight_1_3: 163840
+  my_input_0_0_0: 163840
+  my_model_conv_module.conv.weight_0_0_1_1: 163840
+  my_model_conv_module.conv.bias_1: 163840
+  my_input_1_1_0: 163840
+  my_model_conv_module.conv.weight_1_2_1_0: 163840
+  my_input_1_3_0: 163840
+  my_model_conv_module.conv.bias_0: 163840
+  my_model_conv_module.conv.weight_1_1_1_1: 163840
+  my_input_0_3_1: 163840
+  my_input_2_0_0: 163840
+  my_input_2_2_2: 163840
+  my_model_linear.weight_0_0: 163840
+  my_model_linear.weight_0_3: 163840
+  my_model_conv_module.conv.weight_0_2_1_1: 163840
+  my_model_conv_module.conv.weight_1_0_0_1: 163840
+  my_model_linear.weight_0_1: 163840
+  my_input_2_3_1: 163840
+  my_model_conv_module.conv.weight_0_1_1_1: 163840
+  my_model_conv_module.conv.weight_0_0_1_0: 163840
+  my_input_2_0_1: 163840
+  my_input_1_3_2: 163840
+  my_input_1_0_1: 163840
+  my_model_conv_module.conv.weight_0_0_0_1: 163840
+  my_model_conv_module.conv.weight_1_1_0_0: 163840
+  my_model_linear.weight_1_0: 163840
+  my_input_2_0_2: 163840
+  my_model_conv_module.conv.weight_0_2_0_0: 163840
+  my_input_1_0_2: 163840
+  my_model_conv_module.conv.weight_0_0_0_0: 163840
+  my_model_conv_module.conv.weight_1_2_1_1: 163840
+  my_input_0_2_2: 163840
+  my_model_conv_module.conv.weight_1_2_0_0: 163840
+  my_model_linear.bias_1: 163840
+  my_input_1_0_0: 163840
+  my_input_0_3_2: 163840
+  my_model_conv_module.conv.weight_1_0_1_1: 163840
+  my_model_conv_module.conv.weight_1_1_1_0: 163840
+  my_input_1_2_0: 163840
+  my_input_0_1_1: 163840
+  my_input_0_3_0: 163840
+  my_model_linear.weight_0_2: 163840
+  my_model_conv_module.conv.weight_0_2_1_0: 163840
+  my_model_conv_module.conv.weight_0_1_0_1: 163840
+  my_input_1_2_1: 163840
+  my_input_1_3_1: 163840
+  my_input_0_1_0: 163840
+  my_input_2_3_2: 163840
 expected_outputs:
-  my_output_1:
-    SecretInteger: '101089280'
-  my_output_0:
-    SecretInteger: '101089280'
+  my_output_1: 101089280
+  my_output_0: 101089280

--- a/examples/conv_net/01_provide_model.py
+++ b/examples/conv_net/01_provide_model.py
@@ -9,19 +9,20 @@ import argparse
 import asyncio
 import json
 
-import torch
-from torch import nn
 import nada_numpy as na
 import py_nillion_client as nillion
+import torch
+from common.utils import store_program, store_secrets
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
 from dotenv import load_dotenv
-from nada_ai.client import TorchClient
-from nillion_python_helpers import create_nillion_client, create_payments_config
+from nillion_python_helpers import (create_nillion_client,
+                                    create_payments_config)
 from py_nillion_client import NodeKey, UserKey
+from torch import nn
 
-from common.utils import store_program, store_secrets
+from nada_ai.client import TorchClient
 
 PARSER = argparse.ArgumentParser()
 PARSER.add_argument(

--- a/examples/conv_net/02_run_inference.py
+++ b/examples/conv_net/02_run_inference.py
@@ -14,14 +14,14 @@ import nada_numpy as na
 import nada_numpy.client as na_client
 import numpy as np
 import py_nillion_client as nillion
+from common.utils import compute, store_secret_array
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
 from dotenv import load_dotenv
-from nillion_python_helpers import create_nillion_client, create_payments_config
+from nillion_python_helpers import (create_nillion_client,
+                                    create_payments_config)
 from py_nillion_client import NodeKey, UserKey
-
-from common.utils import compute, store_secret_array
 
 PARSER = argparse.ArgumentParser()
 PARSER.add_argument(

--- a/examples/conv_net/src/my_nn.py
+++ b/examples/conv_net/src/my_nn.py
@@ -1,4 +1,5 @@
 import nada_numpy as na
+
 from nada_ai import nn
 
 

--- a/examples/conv_net/tests/conv_net.yaml
+++ b/examples/conv_net/tests/conv_net.yaml
@@ -1,636 +1,319 @@
----
 program: conv_net
 inputs:
-  my_input_0_0_1_6:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_16:
-    SecretInteger: "3"
-  my_input_0_0_8_15:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_12:
-    SecretInteger: "3"
-  my_input_0_0_14_9:
-    SecretInteger: "3"
-  my_input_0_0_14_7:
-    SecretInteger: "3"
-  my_input_0_0_2_7:
-    SecretInteger: "3"
-  my_input_0_0_11_3:
-    SecretInteger: "3"
-  my_input_0_0_13_9:
-    SecretInteger: "3"
-  my_input_0_0_8_2:
-    SecretInteger: "3"
-  my_input_0_0_0_11:
-    SecretInteger: "3"
-  my_input_0_0_4_10:
-    SecretInteger: "3"
-  my_input_0_0_0_1:
-    SecretInteger: "3"
-  my_input_0_0_13_7:
-    SecretInteger: "3"
-  my_input_0_0_10_1:
-    SecretInteger: "3"
-  my_nn_fc1.bias_1:
-    SecretInteger: "3"
-  my_input_0_0_12_14:
-    SecretInteger: "3"
-  my_input_0_0_11_12:
-    SecretInteger: "3"
-  my_input_0_0_15_10:
-    SecretInteger: "3"
-  my_input_0_0_14_5:
-    SecretInteger: "3"
-  my_input_0_0_15_3:
-    SecretInteger: "3"
-  my_input_0_0_5_15:
-    SecretInteger: "3"
-  my_input_0_0_7_4:
-    SecretInteger: "3"
-  my_input_0_0_3_14:
-    SecretInteger: "3"
-  my_input_0_0_2_13:
-    SecretInteger: "3"
-  my_input_0_0_2_12:
-    SecretInteger: "3"
-  my_input_0_0_0_12:
-    SecretInteger: "3"
-  my_input_0_0_11_6:
-    SecretInteger: "3"
-  my_input_0_0_4_8:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_9:
-    SecretInteger: "3"
-  my_input_0_0_13_3:
-    SecretInteger: "3"
-  my_nn_conv1.weight_1_0_0_0:
-    SecretInteger: "3"
-  my_input_0_0_2_14:
-    SecretInteger: "3"
-  my_input_0_0_10_10:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_12:
-    SecretInteger: "3"
-  my_input_0_0_13_8:
-    SecretInteger: "3"
-  my_nn_conv1.weight_1_0_2_0:
-    SecretInteger: "3"
-  my_input_0_0_1_11:
-    SecretInteger: "3"
-  my_nn_conv1.weight_1_0_2_2:
-    SecretInteger: "3"
-  my_input_0_0_3_15:
-    SecretInteger: "3"
-  my_input_0_0_4_14:
-    SecretInteger: "3"
-  my_input_0_0_9_4:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_0:
-    SecretInteger: "3"
-  my_input_0_0_11_14:
-    SecretInteger: "3"
-  my_input_0_0_12_6:
-    SecretInteger: "3"
-  my_input_0_0_7_11:
-    SecretInteger: "3"
-  my_input_0_0_5_1:
-    SecretInteger: "3"
-  my_input_0_0_0_8:
-    SecretInteger: "3"
-  my_input_0_0_12_3:
-    SecretInteger: "3"
-  my_input_0_0_15_1:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_13:
-    SecretInteger: "3"
-  my_input_0_0_12_0:
-    SecretInteger: "3"
-  my_input_0_0_8_9:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_6:
-    SecretInteger: "3"
-  my_input_0_0_7_7:
-    SecretInteger: "3"
-  my_input_0_0_0_15:
-    SecretInteger: "3"
-  my_nn_conv1.weight_1_0_1_0:
-    SecretInteger: "3"
-  my_input_0_0_13_14:
-    SecretInteger: "3"
-  my_input_0_0_1_1:
-    SecretInteger: "3"
-  my_input_0_0_11_0:
-    SecretInteger: "3"
-  my_input_0_0_5_14:
-    SecretInteger: "3"
-  my_input_0_0_15_2:
-    SecretInteger: "3"
-  my_input_0_0_8_3:
-    SecretInteger: "3"
-  my_input_0_0_9_2:
-    SecretInteger: "3"
-  my_input_0_0_9_1:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_10:
-    SecretInteger: "3"
-  my_input_0_0_10_4:
-    SecretInteger: "3"
-  my_input_0_0_6_0:
-    SecretInteger: "3"
-  my_input_0_0_6_4:
-    SecretInteger: "3"
-  my_nn_conv1.weight_1_0_1_1:
-    SecretInteger: "3"
-  my_input_0_0_12_7:
-    SecretInteger: "3"
-  my_nn_conv1.bias_1:
-    SecretInteger: "3"
-  my_nn_conv1.weight_0_0_1_1:
-    SecretInteger: "3"
-  my_input_0_0_5_12:
-    SecretInteger: "3"
-  my_input_0_0_5_10:
-    SecretInteger: "3"
-  my_input_0_0_9_0:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_10:
-    SecretInteger: "3"
-  my_nn_conv1.weight_1_0_2_1:
-    SecretInteger: "3"
-  my_input_0_0_9_3:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_7:
-    SecretInteger: "3"
-  my_input_0_0_4_4:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_17:
-    SecretInteger: "3"
-  my_input_0_0_14_11:
-    SecretInteger: "3"
-  my_input_0_0_12_8:
-    SecretInteger: "3"
-  my_input_0_0_9_5:
-    SecretInteger: "3"
-  my_input_0_0_10_12:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_3:
-    SecretInteger: "3"
-  my_input_0_0_13_5:
-    SecretInteger: "3"
-  my_input_0_0_7_6:
-    SecretInteger: "3"
-  my_nn_conv1.weight_0_0_1_2:
-    SecretInteger: "3"
-  my_input_0_0_12_2:
-    SecretInteger: "3"
-  my_input_0_0_12_11:
-    SecretInteger: "3"
-  my_input_0_0_13_11:
-    SecretInteger: "3"
-  my_input_0_0_14_6:
-    SecretInteger: "3"
-  my_input_0_0_11_1:
-    SecretInteger: "3"
-  my_input_0_0_5_11:
-    SecretInteger: "3"
-  my_input_0_0_7_1:
-    SecretInteger: "3"
-  my_input_0_0_2_10:
-    SecretInteger: "3"
-  my_input_0_0_1_2:
-    SecretInteger: "3"
-  my_input_0_0_11_11:
-    SecretInteger: "3"
-  my_input_0_0_9_11:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_5:
-    SecretInteger: "3"
-  my_input_0_0_10_13:
-    SecretInteger: "3"
-  my_input_0_0_8_6:
-    SecretInteger: "3"
-  my_input_0_0_7_5:
-    SecretInteger: "3"
-  my_input_0_0_15_14:
-    SecretInteger: "3"
-  my_input_0_0_10_15:
-    SecretInteger: "3"
-  my_input_0_0_6_1:
-    SecretInteger: "3"
-  my_input_0_0_2_9:
-    SecretInteger: "3"
-  my_nn_conv1.weight_0_0_0_2:
-    SecretInteger: "3"
-  my_input_0_0_8_13:
-    SecretInteger: "3"
-  my_input_0_0_8_7:
-    SecretInteger: "3"
-  my_input_0_0_15_4:
-    SecretInteger: "3"
-  my_input_0_0_1_9:
-    SecretInteger: "3"
-  my_input_0_0_0_5:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_15:
-    SecretInteger: "3"
-  my_input_0_0_12_5:
-    SecretInteger: "3"
-  my_input_0_0_9_7:
-    SecretInteger: "3"
-  my_input_0_0_0_7:
-    SecretInteger: "3"
-  my_input_0_0_4_1:
-    SecretInteger: "3"
-  my_input_0_0_3_10:
-    SecretInteger: "3"
-  my_input_0_0_0_9:
-    SecretInteger: "3"
-  my_input_0_0_1_4:
-    SecretInteger: "3"
-  my_input_0_0_7_15:
-    SecretInteger: "3"
-  my_input_0_0_11_13:
-    SecretInteger: "3"
-  my_input_0_0_12_9:
-    SecretInteger: "3"
-  my_input_0_0_1_10:
-    SecretInteger: "3"
-  my_input_0_0_13_1:
-    SecretInteger: "3"
-  my_input_0_0_11_15:
-    SecretInteger: "3"
-  my_input_0_0_0_10:
-    SecretInteger: "3"
-  my_input_0_0_1_15:
-    SecretInteger: "3"
-  my_input_0_0_1_7:
-    SecretInteger: "3"
-  my_input_0_0_3_4:
-    SecretInteger: "3"
-  my_input_0_0_11_5:
-    SecretInteger: "3"
-  my_input_0_0_12_13:
-    SecretInteger: "3"
-  my_input_0_0_11_4:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_0:
-    SecretInteger: "3"
-  my_input_0_0_14_13:
-    SecretInteger: "3"
-  my_input_0_0_13_12:
-    SecretInteger: "3"
-  my_input_0_0_10_8:
-    SecretInteger: "3"
-  my_input_0_0_13_15:
-    SecretInteger: "3"
-  my_input_0_0_3_0:
-    SecretInteger: "3"
-  my_input_0_0_0_2:
-    SecretInteger: "3"
-  my_input_0_0_3_6:
-    SecretInteger: "3"
-  my_input_0_0_11_8:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_1:
-    SecretInteger: "3"
-  my_input_0_0_6_6:
-    SecretInteger: "3"
-  my_input_0_0_1_8:
-    SecretInteger: "3"
-  my_input_0_0_1_0:
-    SecretInteger: "3"
-  my_input_0_0_14_12:
-    SecretInteger: "3"
-  my_input_0_0_15_13:
-    SecretInteger: "3"
-  my_input_0_0_7_14:
-    SecretInteger: "3"
-  my_input_0_0_3_11:
-    SecretInteger: "3"
-  my_input_0_0_14_10:
-    SecretInteger: "3"
-  my_input_0_0_14_1:
-    SecretInteger: "3"
-  my_input_0_0_14_3:
-    SecretInteger: "3"
-  my_input_0_0_10_6:
-    SecretInteger: "3"
-  my_input_0_0_10_0:
-    SecretInteger: "3"
-  my_input_0_0_8_8:
-    SecretInteger: "3"
-  my_input_0_0_15_12:
-    SecretInteger: "3"
-  my_input_0_0_3_1:
-    SecretInteger: "3"
-  my_input_0_0_2_8:
-    SecretInteger: "3"
-  my_input_0_0_7_12:
-    SecretInteger: "3"
-  my_input_0_0_0_0:
-    SecretInteger: "3"
-  my_input_0_0_4_0:
-    SecretInteger: "3"
-  my_input_0_0_15_9:
-    SecretInteger: "3"
-  my_input_0_0_0_13:
-    SecretInteger: "3"
-  my_input_0_0_2_4:
-    SecretInteger: "3"
-  my_input_0_0_1_12:
-    SecretInteger: "3"
-  my_input_0_0_11_10:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_7:
-    SecretInteger: "3"
-  my_input_0_0_8_10:
-    SecretInteger: "3"
-  my_input_0_0_2_2:
-    SecretInteger: "3"
-  my_input_0_0_13_10:
-    SecretInteger: "3"
-  my_input_0_0_6_13:
-    SecretInteger: "3"
-  my_input_0_0_8_4:
-    SecretInteger: "3"
-  my_input_0_0_6_9:
-    SecretInteger: "3"
-  my_input_0_0_14_4:
-    SecretInteger: "3"
-  my_input_0_0_6_14:
-    SecretInteger: "3"
-  my_input_0_0_6_11:
-    SecretInteger: "3"
-  my_input_0_0_4_3:
-    SecretInteger: "3"
-  my_input_0_0_7_13:
-    SecretInteger: "3"
-  my_input_0_0_4_6:
-    SecretInteger: "3"
-  my_input_0_0_10_2:
-    SecretInteger: "3"
-  my_input_0_0_9_15:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_14:
-    SecretInteger: "3"
-  my_input_0_0_0_14:
-    SecretInteger: "3"
-  my_input_0_0_9_6:
-    SecretInteger: "3"
-  my_input_0_0_10_11:
-    SecretInteger: "3"
-  my_input_0_0_3_12:
-    SecretInteger: "3"
-  my_input_0_0_1_13:
-    SecretInteger: "3"
-  my_input_0_0_13_2:
-    SecretInteger: "3"
-  my_input_0_0_3_7:
-    SecretInteger: "3"
-  my_input_0_0_3_2:
-    SecretInteger: "3"
-  my_input_0_0_4_5:
-    SecretInteger: "3"
-  my_input_0_0_12_4:
-    SecretInteger: "3"
-  my_input_0_0_2_15:
-    SecretInteger: "3"
-  my_input_0_0_15_11:
-    SecretInteger: "3"
-  my_input_0_0_13_0:
-    SecretInteger: "3"
-  my_input_0_0_10_7:
-    SecretInteger: "3"
-  my_input_0_0_7_8:
-    SecretInteger: "3"
-  my_input_0_0_4_13:
-    SecretInteger: "3"
-  my_input_0_0_4_2:
-    SecretInteger: "3"
-  my_input_0_0_8_1:
-    SecretInteger: "3"
-  my_input_0_0_14_14:
-    SecretInteger: "3"
-  my_input_0_0_5_0:
-    SecretInteger: "3"
-  my_nn_fc1.bias_0:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_15:
-    SecretInteger: "3"
-  my_input_0_0_5_4:
-    SecretInteger: "3"
-  my_input_0_0_0_4:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_8:
-    SecretInteger: "3"
-  my_input_0_0_9_9:
-    SecretInteger: "3"
-  my_input_0_0_2_3:
-    SecretInteger: "3"
-  my_input_0_0_0_3:
-    SecretInteger: "3"
-  my_input_0_0_9_13:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_9:
-    SecretInteger: "3"
-  my_input_0_0_3_5:
-    SecretInteger: "3"
-  my_input_0_0_7_0:
-    SecretInteger: "3"
-  my_input_0_0_6_10:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_6:
-    SecretInteger: "3"
-  my_input_0_0_8_5:
-    SecretInteger: "3"
-  my_input_0_0_10_9:
-    SecretInteger: "3"
-  my_input_0_0_5_9:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_16:
-    SecretInteger: "3"
-  my_input_0_0_14_15:
-    SecretInteger: "3"
-  my_input_0_0_2_6:
-    SecretInteger: "3"
-  my_input_0_0_14_0:
-    SecretInteger: "3"
-  my_input_0_0_10_3:
-    SecretInteger: "3"
-  my_input_0_0_10_5:
-    SecretInteger: "3"
-  my_input_0_0_4_11:
-    SecretInteger: "3"
-  my_input_0_0_1_14:
-    SecretInteger: "3"
-  my_nn_conv1.weight_1_0_1_2:
-    SecretInteger: "3"
-  my_input_0_0_15_8:
-    SecretInteger: "3"
-  my_input_0_0_3_13:
-    SecretInteger: "3"
-  my_nn_conv1.weight_1_0_0_1:
-    SecretInteger: "3"
-  my_input_0_0_2_0:
-    SecretInteger: "3"
-  my_input_0_0_1_3:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_11:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_13:
-    SecretInteger: "3"
-  my_input_0_0_12_1:
-    SecretInteger: "3"
-  my_input_0_0_15_7:
-    SecretInteger: "3"
-  my_input_0_0_14_8:
-    SecretInteger: "3"
-  my_input_0_0_15_15:
-    SecretInteger: "3"
-  my_input_0_0_6_8:
-    SecretInteger: "3"
-  my_input_0_0_5_2:
-    SecretInteger: "3"
-  my_input_0_0_2_5:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_5:
-    SecretInteger: "3"
-  my_input_0_0_12_10:
-    SecretInteger: "3"
-  my_nn_conv1.bias_0:
-    SecretInteger: "3"
-  my_input_0_0_7_10:
-    SecretInteger: "3"
-  my_input_0_0_8_14:
-    SecretInteger: "3"
-  my_input_0_0_7_3:
-    SecretInteger: "3"
-  my_input_0_0_6_2:
-    SecretInteger: "3"
-  my_input_0_0_5_13:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_2:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_1:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_17:
-    SecretInteger: "3"
-  my_input_0_0_13_6:
-    SecretInteger: "3"
-  my_input_0_0_1_5:
-    SecretInteger: "3"
-  my_input_0_0_0_6:
-    SecretInteger: "3"
-  my_input_0_0_7_2:
-    SecretInteger: "3"
-  my_input_0_0_9_12:
-    SecretInteger: "3"
-  my_input_0_0_6_12:
-    SecretInteger: "3"
-  my_input_0_0_4_7:
-    SecretInteger: "3"
-  my_input_0_0_9_14:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_4:
-    SecretInteger: "3"
-  my_nn_conv1.weight_0_0_2_0:
-    SecretInteger: "3"
-  my_input_0_0_13_4:
-    SecretInteger: "3"
-  my_input_0_0_6_5:
-    SecretInteger: "3"
-  my_input_0_0_3_3:
-    SecretInteger: "3"
-  my_input_0_0_5_3:
-    SecretInteger: "3"
-  my_nn_conv1.weight_0_0_0_1:
-    SecretInteger: "3"
-  my_input_0_0_4_9:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_4:
-    SecretInteger: "3"
-  my_nn_conv1.weight_0_0_0_0:
-    SecretInteger: "3"
-  my_input_0_0_15_6:
-    SecretInteger: "3"
-  my_input_0_0_8_12:
-    SecretInteger: "3"
-  my_input_0_0_10_14:
-    SecretInteger: "3"
-  my_input_0_0_9_8:
-    SecretInteger: "3"
-  my_input_0_0_5_7:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_14:
-    SecretInteger: "3"
-  my_nn_conv1.weight_0_0_2_2:
-    SecretInteger: "3"
-  my_nn_conv1.weight_0_0_1_0:
-    SecretInteger: "3"
-  my_input_0_0_4_15:
-    SecretInteger: "3"
-  my_input_0_0_6_7:
-    SecretInteger: "3"
-  my_input_0_0_8_11:
-    SecretInteger: "3"
-  my_input_0_0_5_8:
-    SecretInteger: "3"
-  my_input_0_0_4_12:
-    SecretInteger: "3"
-  my_input_0_0_12_12:
-    SecretInteger: "3"
-  my_input_0_0_2_11:
-    SecretInteger: "3"
-  my_nn_fc1.weight_1_3:
-    SecretInteger: "3"
-  my_input_0_0_3_9:
-    SecretInteger: "3"
-  my_input_0_0_2_1:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_8:
-    SecretInteger: "3"
-  my_input_0_0_5_5:
-    SecretInteger: "3"
-  my_input_0_0_11_2:
-    SecretInteger: "3"
-  my_input_0_0_6_3:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_11:
-    SecretInteger: "3"
-  my_input_0_0_11_7:
-    SecretInteger: "3"
-  my_input_0_0_15_0:
-    SecretInteger: "3"
-  my_nn_conv1.weight_1_0_0_2:
-    SecretInteger: "3"
-  my_input_0_0_15_5:
-    SecretInteger: "3"
-  my_input_0_0_13_13:
-    SecretInteger: "3"
-  my_input_0_0_11_9:
-    SecretInteger: "3"
-  my_input_0_0_6_15:
-    SecretInteger: "3"
-  my_input_0_0_9_10:
-    SecretInteger: "3"
-  my_input_0_0_5_6:
-    SecretInteger: "3"
-  my_nn_fc1.weight_0_2:
-    SecretInteger: "3"
-  my_input_0_0_14_2:
-    SecretInteger: "3"
-  my_nn_conv1.weight_0_0_2_1:
-    SecretInteger: "3"
-  my_input_0_0_7_9:
-    SecretInteger: "3"
-  my_input_0_0_8_0:
-    SecretInteger: "3"
-  my_input_0_0_3_8:
-    SecretInteger: "3"
-  my_input_0_0_12_15:
-    SecretInteger: "3"
+  my_input_0_0_1_6: 3
+  my_nn_fc1.weight_0_16: 3
+  my_input_0_0_8_15: 3
+  my_nn_fc1.weight_0_12: 3
+  my_input_0_0_14_9: 3
+  my_input_0_0_14_7: 3
+  my_input_0_0_2_7: 3
+  my_input_0_0_11_3: 3
+  my_input_0_0_13_9: 3
+  my_input_0_0_8_2: 3
+  my_input_0_0_0_11: 3
+  my_input_0_0_4_10: 3
+  my_input_0_0_0_1: 3
+  my_input_0_0_13_7: 3
+  my_input_0_0_10_1: 3
+  my_nn_fc1.bias_1: 3
+  my_input_0_0_12_14: 3
+  my_input_0_0_11_12: 3
+  my_input_0_0_15_10: 3
+  my_input_0_0_14_5: 3
+  my_input_0_0_15_3: 3
+  my_input_0_0_5_15: 3
+  my_input_0_0_7_4: 3
+  my_input_0_0_3_14: 3
+  my_input_0_0_2_13: 3
+  my_input_0_0_2_12: 3
+  my_input_0_0_0_12: 3
+  my_input_0_0_11_6: 3
+  my_input_0_0_4_8: 3
+  my_nn_fc1.weight_0_9: 3
+  my_input_0_0_13_3: 3
+  my_nn_conv1.weight_1_0_0_0: 3
+  my_input_0_0_2_14: 3
+  my_input_0_0_10_10: 3
+  my_nn_fc1.weight_1_12: 3
+  my_input_0_0_13_8: 3
+  my_nn_conv1.weight_1_0_2_0: 3
+  my_input_0_0_1_11: 3
+  my_nn_conv1.weight_1_0_2_2: 3
+  my_input_0_0_3_15: 3
+  my_input_0_0_4_14: 3
+  my_input_0_0_9_4: 3
+  my_nn_fc1.weight_1_0: 3
+  my_input_0_0_11_14: 3
+  my_input_0_0_12_6: 3
+  my_input_0_0_7_11: 3
+  my_input_0_0_5_1: 3
+  my_input_0_0_0_8: 3
+  my_input_0_0_12_3: 3
+  my_input_0_0_15_1: 3
+  my_nn_fc1.weight_1_13: 3
+  my_input_0_0_12_0: 3
+  my_input_0_0_8_9: 3
+  my_nn_fc1.weight_1_6: 3
+  my_input_0_0_7_7: 3
+  my_input_0_0_0_15: 3
+  my_nn_conv1.weight_1_0_1_0: 3
+  my_input_0_0_13_14: 3
+  my_input_0_0_1_1: 3
+  my_input_0_0_11_0: 3
+  my_input_0_0_5_14: 3
+  my_input_0_0_15_2: 3
+  my_input_0_0_8_3: 3
+  my_input_0_0_9_2: 3
+  my_input_0_0_9_1: 3
+  my_nn_fc1.weight_1_10: 3
+  my_input_0_0_10_4: 3
+  my_input_0_0_6_0: 3
+  my_input_0_0_6_4: 3
+  my_nn_conv1.weight_1_0_1_1: 3
+  my_input_0_0_12_7: 3
+  my_nn_conv1.bias_1: 3
+  my_nn_conv1.weight_0_0_1_1: 3
+  my_input_0_0_5_12: 3
+  my_input_0_0_5_10: 3
+  my_input_0_0_9_0: 3
+  my_nn_fc1.weight_0_10: 3
+  my_nn_conv1.weight_1_0_2_1: 3
+  my_input_0_0_9_3: 3
+  my_nn_fc1.weight_0_7: 3
+  my_input_0_0_4_4: 3
+  my_nn_fc1.weight_1_17: 3
+  my_input_0_0_14_11: 3
+  my_input_0_0_12_8: 3
+  my_input_0_0_9_5: 3
+  my_input_0_0_10_12: 3
+  my_nn_fc1.weight_0_3: 3
+  my_input_0_0_13_5: 3
+  my_input_0_0_7_6: 3
+  my_nn_conv1.weight_0_0_1_2: 3
+  my_input_0_0_12_2: 3
+  my_input_0_0_12_11: 3
+  my_input_0_0_13_11: 3
+  my_input_0_0_14_6: 3
+  my_input_0_0_11_1: 3
+  my_input_0_0_5_11: 3
+  my_input_0_0_7_1: 3
+  my_input_0_0_2_10: 3
+  my_input_0_0_1_2: 3
+  my_input_0_0_11_11: 3
+  my_input_0_0_9_11: 3
+  my_nn_fc1.weight_0_5: 3
+  my_input_0_0_10_13: 3
+  my_input_0_0_8_6: 3
+  my_input_0_0_7_5: 3
+  my_input_0_0_15_14: 3
+  my_input_0_0_10_15: 3
+  my_input_0_0_6_1: 3
+  my_input_0_0_2_9: 3
+  my_nn_conv1.weight_0_0_0_2: 3
+  my_input_0_0_8_13: 3
+  my_input_0_0_8_7: 3
+  my_input_0_0_15_4: 3
+  my_input_0_0_1_9: 3
+  my_input_0_0_0_5: 3
+  my_nn_fc1.weight_0_15: 3
+  my_input_0_0_12_5: 3
+  my_input_0_0_9_7: 3
+  my_input_0_0_0_7: 3
+  my_input_0_0_4_1: 3
+  my_input_0_0_3_10: 3
+  my_input_0_0_0_9: 3
+  my_input_0_0_1_4: 3
+  my_input_0_0_7_15: 3
+  my_input_0_0_11_13: 3
+  my_input_0_0_12_9: 3
+  my_input_0_0_1_10: 3
+  my_input_0_0_13_1: 3
+  my_input_0_0_11_15: 3
+  my_input_0_0_0_10: 3
+  my_input_0_0_1_15: 3
+  my_input_0_0_1_7: 3
+  my_input_0_0_3_4: 3
+  my_input_0_0_11_5: 3
+  my_input_0_0_12_13: 3
+  my_input_0_0_11_4: 3
+  my_nn_fc1.weight_0_0: 3
+  my_input_0_0_14_13: 3
+  my_input_0_0_13_12: 3
+  my_input_0_0_10_8: 3
+  my_input_0_0_13_15: 3
+  my_input_0_0_3_0: 3
+  my_input_0_0_0_2: 3
+  my_input_0_0_3_6: 3
+  my_input_0_0_11_8: 3
+  my_nn_fc1.weight_0_1: 3
+  my_input_0_0_6_6: 3
+  my_input_0_0_1_8: 3
+  my_input_0_0_1_0: 3
+  my_input_0_0_14_12: 3
+  my_input_0_0_15_13: 3
+  my_input_0_0_7_14: 3
+  my_input_0_0_3_11: 3
+  my_input_0_0_14_10: 3
+  my_input_0_0_14_1: 3
+  my_input_0_0_14_3: 3
+  my_input_0_0_10_6: 3
+  my_input_0_0_10_0: 3
+  my_input_0_0_8_8: 3
+  my_input_0_0_15_12: 3
+  my_input_0_0_3_1: 3
+  my_input_0_0_2_8: 3
+  my_input_0_0_7_12: 3
+  my_input_0_0_0_0: 3
+  my_input_0_0_4_0: 3
+  my_input_0_0_15_9: 3
+  my_input_0_0_0_13: 3
+  my_input_0_0_2_4: 3
+  my_input_0_0_1_12: 3
+  my_input_0_0_11_10: 3
+  my_nn_fc1.weight_1_7: 3
+  my_input_0_0_8_10: 3
+  my_input_0_0_2_2: 3
+  my_input_0_0_13_10: 3
+  my_input_0_0_6_13: 3
+  my_input_0_0_8_4: 3
+  my_input_0_0_6_9: 3
+  my_input_0_0_14_4: 3
+  my_input_0_0_6_14: 3
+  my_input_0_0_6_11: 3
+  my_input_0_0_4_3: 3
+  my_input_0_0_7_13: 3
+  my_input_0_0_4_6: 3
+  my_input_0_0_10_2: 3
+  my_input_0_0_9_15: 3
+  my_nn_fc1.weight_0_14: 3
+  my_input_0_0_0_14: 3
+  my_input_0_0_9_6: 3
+  my_input_0_0_10_11: 3
+  my_input_0_0_3_12: 3
+  my_input_0_0_1_13: 3
+  my_input_0_0_13_2: 3
+  my_input_0_0_3_7: 3
+  my_input_0_0_3_2: 3
+  my_input_0_0_4_5: 3
+  my_input_0_0_12_4: 3
+  my_input_0_0_2_15: 3
+  my_input_0_0_15_11: 3
+  my_input_0_0_13_0: 3
+  my_input_0_0_10_7: 3
+  my_input_0_0_7_8: 3
+  my_input_0_0_4_13: 3
+  my_input_0_0_4_2: 3
+  my_input_0_0_8_1: 3
+  my_input_0_0_14_14: 3
+  my_input_0_0_5_0: 3
+  my_nn_fc1.bias_0: 3
+  my_nn_fc1.weight_1_15: 3
+  my_input_0_0_5_4: 3
+  my_input_0_0_0_4: 3
+  my_nn_fc1.weight_1_8: 3
+  my_input_0_0_9_9: 3
+  my_input_0_0_2_3: 3
+  my_input_0_0_0_3: 3
+  my_input_0_0_9_13: 3
+  my_nn_fc1.weight_1_9: 3
+  my_input_0_0_3_5: 3
+  my_input_0_0_7_0: 3
+  my_input_0_0_6_10: 3
+  my_nn_fc1.weight_0_6: 3
+  my_input_0_0_8_5: 3
+  my_input_0_0_10_9: 3
+  my_input_0_0_5_9: 3
+  my_nn_fc1.weight_1_16: 3
+  my_input_0_0_14_15: 3
+  my_input_0_0_2_6: 3
+  my_input_0_0_14_0: 3
+  my_input_0_0_10_3: 3
+  my_input_0_0_10_5: 3
+  my_input_0_0_4_11: 3
+  my_input_0_0_1_14: 3
+  my_nn_conv1.weight_1_0_1_2: 3
+  my_input_0_0_15_8: 3
+  my_input_0_0_3_13: 3
+  my_nn_conv1.weight_1_0_0_1: 3
+  my_input_0_0_2_0: 3
+  my_input_0_0_1_3: 3
+  my_nn_fc1.weight_1_11: 3
+  my_nn_fc1.weight_0_13: 3
+  my_input_0_0_12_1: 3
+  my_input_0_0_15_7: 3
+  my_input_0_0_14_8: 3
+  my_input_0_0_15_15: 3
+  my_input_0_0_6_8: 3
+  my_input_0_0_5_2: 3
+  my_input_0_0_2_5: 3
+  my_nn_fc1.weight_1_5: 3
+  my_input_0_0_12_10: 3
+  my_nn_conv1.bias_0: 3
+  my_input_0_0_7_10: 3
+  my_input_0_0_8_14: 3
+  my_input_0_0_7_3: 3
+  my_input_0_0_6_2: 3
+  my_input_0_0_5_13: 3
+  my_nn_fc1.weight_1_2: 3
+  my_nn_fc1.weight_1_1: 3
+  my_nn_fc1.weight_0_17: 3
+  my_input_0_0_13_6: 3
+  my_input_0_0_1_5: 3
+  my_input_0_0_0_6: 3
+  my_input_0_0_7_2: 3
+  my_input_0_0_9_12: 3
+  my_input_0_0_6_12: 3
+  my_input_0_0_4_7: 3
+  my_input_0_0_9_14: 3
+  my_nn_fc1.weight_0_4: 3
+  my_nn_conv1.weight_0_0_2_0: 3
+  my_input_0_0_13_4: 3
+  my_input_0_0_6_5: 3
+  my_input_0_0_3_3: 3
+  my_input_0_0_5_3: 3
+  my_nn_conv1.weight_0_0_0_1: 3
+  my_input_0_0_4_9: 3
+  my_nn_fc1.weight_1_4: 3
+  my_nn_conv1.weight_0_0_0_0: 3
+  my_input_0_0_15_6: 3
+  my_input_0_0_8_12: 3
+  my_input_0_0_10_14: 3
+  my_input_0_0_9_8: 3
+  my_input_0_0_5_7: 3
+  my_nn_fc1.weight_1_14: 3
+  my_nn_conv1.weight_0_0_2_2: 3
+  my_nn_conv1.weight_0_0_1_0: 3
+  my_input_0_0_4_15: 3
+  my_input_0_0_6_7: 3
+  my_input_0_0_8_11: 3
+  my_input_0_0_5_8: 3
+  my_input_0_0_4_12: 3
+  my_input_0_0_12_12: 3
+  my_input_0_0_2_11: 3
+  my_nn_fc1.weight_1_3: 3
+  my_input_0_0_3_9: 3
+  my_input_0_0_2_1: 3
+  my_nn_fc1.weight_0_8: 3
+  my_input_0_0_5_5: 3
+  my_input_0_0_11_2: 3
+  my_input_0_0_6_3: 3
+  my_nn_fc1.weight_0_11: 3
+  my_input_0_0_11_7: 3
+  my_input_0_0_15_0: 3
+  my_nn_conv1.weight_1_0_0_2: 3
+  my_input_0_0_15_5: 3
+  my_input_0_0_13_13: 3
+  my_input_0_0_11_9: 3
+  my_input_0_0_6_15: 3
+  my_input_0_0_9_10: 3
+  my_input_0_0_5_6: 3
+  my_nn_fc1.weight_0_2: 3
+  my_input_0_0_14_2: 3
+  my_nn_conv1.weight_0_0_2_1: 3
+  my_input_0_0_7_9: 3
+  my_input_0_0_8_0: 3
+  my_input_0_0_3_8: 3
+  my_input_0_0_12_15: 3
 expected_outputs:
-  my_output_0_0:
-    SecretInteger: "3"
-  my_output_0_1:
-    SecretInteger: "3"
+  my_output_0_0: 3
+  my_output_0_1: 3

--- a/examples/linear_regression/main.py
+++ b/examples/linear_regression/main.py
@@ -11,17 +11,18 @@ import nada_numpy as na
 import nada_numpy.client as na_client
 import numpy as np
 import py_nillion_client as nillion
+from common.utils import compute, store_program, store_secrets
 from config import DIM
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
 from dotenv import load_dotenv
-from nada_ai.client import SklearnClient
-from nillion_python_helpers import create_nillion_client, create_payments_config
+from nillion_python_helpers import (create_nillion_client,
+                                    create_payments_config)
 from py_nillion_client import NodeKey, UserKey
 from sklearn.linear_model import LinearRegression
 
-from common.utils import compute, store_program, store_secrets
+from nada_ai.client import SklearnClient
 
 home = os.getenv("HOME")
 load_dotenv(f"{home}/.config/nillion/nillion-devnet.env")

--- a/examples/linear_regression/src/linear_regression.py
+++ b/examples/linear_regression/src/linear_regression.py
@@ -1,5 +1,6 @@
 import nada_numpy as na
 from config import DIM
+
 from nada_ai.linear_model import LinearRegression
 
 

--- a/examples/linear_regression/tests/linear_regression.yaml
+++ b/examples/linear_regression/tests/linear_regression.yaml
@@ -1,47 +1,25 @@
 program: linear_regression
 inputs:
-  my_model_coef_0:
-    SecretInteger: '30669'
-  my_model_coef_1:
-    SecretInteger: '22411'
-  my_model_coef_2:
-    SecretInteger: '61182'
-  my_model_coef_3:
-    SecretInteger: '23548'
-  my_model_coef_4:
-    SecretInteger: '52068'
-  my_model_coef_5:
-    SecretInteger: '49177'
-  my_model_coef_6:
-    SecretInteger: '60541'
-  my_model_coef_7:
-    SecretInteger: '55932'
-  my_model_coef_8:
-    SecretInteger: '7771'
-  my_model_coef_9:
-    SecretInteger: '61119'
-  my_model_intercept_0:
-    SecretInteger: '45040'
-  my_input_0:
-    SecretInteger: '163840'
-  my_input_1:
-    SecretInteger: '163840'
-  my_input_2:
-    SecretInteger: '163840'
-  my_input_3:
-    SecretInteger: '163840'
-  my_input_4:
-    SecretInteger: '163840'
-  my_input_5:
-    SecretInteger: '163840'
-  my_input_6:
-    SecretInteger: '163840'
-  my_input_7:
-    SecretInteger: '163840'
-  my_input_8:
-    SecretInteger: '163840'
-  my_input_9:
-    SecretInteger: '163840'
+  my_model_coef_0: 30669
+  my_model_coef_1: 22411
+  my_model_coef_2: 61182
+  my_model_coef_3: 23548
+  my_model_coef_4: 52068
+  my_model_coef_5: 49177
+  my_model_coef_6: 60541
+  my_model_coef_7: 55932
+  my_model_coef_8: 7771
+  my_model_coef_9: 61119
+  my_model_intercept_0: 45040
+  my_input_0: 163840
+  my_input_1: 163840
+  my_input_2: 163840
+  my_input_3: 163840
+  my_input_4: 163840
+  my_input_5: 163840
+  my_input_6: 163840
+  my_input_7: 163840
+  my_input_8: 163840
+  my_input_9: 163840
 expected_outputs:
-  my_output:
-    SecretInteger: '1106085'
+  my_output: 1106085

--- a/examples/neural_net/main.py
+++ b/examples/neural_net/main.py
@@ -12,16 +12,17 @@ import nada_numpy.client as na_client
 import numpy as np
 import py_nillion_client as nillion
 import torch
+from common.utils import compute, store_program, store_secrets
 from config import DIM
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
 from dotenv import load_dotenv
-from nada_ai.client import TorchClient
-from nillion_python_helpers import create_nillion_client, create_payments_config
+from nillion_python_helpers import (create_nillion_client,
+                                    create_payments_config)
 from py_nillion_client import NodeKey, UserKey
 
-from common.utils import compute, store_program, store_secrets
+from nada_ai.client import TorchClient
 
 home = os.getenv("HOME")
 load_dotenv(f"{home}/.config/nillion/nillion-devnet.env")

--- a/examples/neural_net/src/my_nn.py
+++ b/examples/neural_net/src/my_nn.py
@@ -1,5 +1,6 @@
 import nada_numpy as na
 from config import DIM
+
 from nada_ai import nn
 
 

--- a/examples/neural_net/tests/neural_net.yaml
+++ b/examples/neural_net/tests/neural_net.yaml
@@ -1,115 +1,59 @@
 program: neural_net
 inputs:
-  my_nn_linear_0.weight_1_2:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_2_4:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_1_7:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_0_4:
-    SecretInteger: '163840'
-  my_nn_linear_0.bias_2:
-    SecretInteger: '163840'
-  my_nn_linear_1.weight_0_3:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_3_1:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_3_6:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_1_3:
-    SecretInteger: '163840'
-  my_nn_linear_0.bias_3:
-    SecretInteger: '163840'
-  my_nn_linear_1.weight_1_1:
-    SecretInteger: '163840'
-  my_input_0:
-    SecretInteger: '163840'
-  my_input_4:
-    SecretInteger: '163840'
-  my_nn_linear_1.weight_0_0:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_3_0:
-    SecretInteger: '163840'
-  my_nn_linear_1.weight_1_2:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_0_1:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_2_2:
-    SecretInteger: '163840'
-  my_input_2:
-    SecretInteger: '163840'
-  my_nn_linear_1.weight_1_0:
-    SecretInteger: '163840'
-  my_input_1:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_0_0:
-    SecretInteger: '163840'
-  my_input_6:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_0_5:
-    SecretInteger: '163840'
-  my_nn_linear_1.weight_0_1:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_0_2:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_1_1:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_2_1:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_2_3:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_2_7:
-    SecretInteger: '163840'
-  my_nn_linear_1.weight_1_3:
-    SecretInteger: '163840'
-  my_nn_linear_0.bias_1:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_1_4:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_2_5:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_0_3:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_3_5:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_3_7:
-    SecretInteger: '163840'
-  my_input_5:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_2_0:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_1_0:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_1_6:
-    SecretInteger: '163840'
-  my_nn_linear_1.weight_0_2:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_3_4:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_3_3:
-    SecretInteger: '163840'
-  my_input_3:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_3_2:
-    SecretInteger: '163840'
-  my_nn_linear_1.bias_1:
-    SecretInteger: '163840'
-  my_input_7:
-    SecretInteger: '163840'
-  my_nn_linear_0.bias_0:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_0_6:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_2_6:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_1_5:
-    SecretInteger: '163840'
-  my_nn_linear_1.bias_0:
-    SecretInteger: '163840'
-  my_nn_linear_0.weight_0_7:
-    SecretInteger: '163840'
+  my_nn_linear_0.weight_1_2: 163840
+  my_nn_linear_0.weight_2_4: 163840
+  my_nn_linear_0.weight_1_7: 163840
+  my_nn_linear_0.weight_0_4: 163840
+  my_nn_linear_0.bias_2: 163840
+  my_nn_linear_1.weight_0_3: 163840
+  my_nn_linear_0.weight_3_1: 163840
+  my_nn_linear_0.weight_3_6: 163840
+  my_nn_linear_0.weight_1_3: 163840
+  my_nn_linear_0.bias_3: 163840
+  my_nn_linear_1.weight_1_1: 163840
+  my_input_0: 163840
+  my_input_4: 163840
+  my_nn_linear_1.weight_0_0: 163840
+  my_nn_linear_0.weight_3_0: 163840
+  my_nn_linear_1.weight_1_2: 163840
+  my_nn_linear_0.weight_0_1: 163840
+  my_nn_linear_0.weight_2_2: 163840
+  my_input_2: 163840
+  my_nn_linear_1.weight_1_0: 163840
+  my_input_1: 163840
+  my_nn_linear_0.weight_0_0: 163840
+  my_input_6: 163840
+  my_nn_linear_0.weight_0_5: 163840
+  my_nn_linear_1.weight_0_1: 163840
+  my_nn_linear_0.weight_0_2: 163840
+  my_nn_linear_0.weight_1_1: 163840
+  my_nn_linear_0.weight_2_1: 163840
+  my_nn_linear_0.weight_2_3: 163840
+  my_nn_linear_0.weight_2_7: 163840
+  my_nn_linear_1.weight_1_3: 163840
+  my_nn_linear_0.bias_1: 163840
+  my_nn_linear_0.weight_1_4: 163840
+  my_nn_linear_0.weight_2_5: 163840
+  my_nn_linear_0.weight_0_3: 163840
+  my_nn_linear_0.weight_3_5: 163840
+  my_nn_linear_0.weight_3_7: 163840
+  my_input_5: 163840
+  my_nn_linear_0.weight_2_0: 163840
+  my_nn_linear_0.weight_1_0: 163840
+  my_nn_linear_0.weight_1_6: 163840
+  my_nn_linear_1.weight_0_2: 163840
+  my_nn_linear_0.weight_3_4: 163840
+  my_nn_linear_0.weight_3_3: 163840
+  my_input_3: 163840
+  my_nn_linear_0.weight_3_2: 163840
+  my_nn_linear_1.bias_1: 163840
+  my_input_7: 163840
+  my_nn_linear_0.bias_0: 163840
+  my_nn_linear_0.weight_0_6: 163840
+  my_nn_linear_0.weight_2_6: 163840
+  my_nn_linear_0.weight_1_5: 163840
+  my_nn_linear_1.bias_0: 163840
+  my_nn_linear_0.weight_0_7: 163840
 expected_outputs:
-  my_output_0:
-    SecretInteger: '34570240'
-  my_output_1:
-    SecretInteger: '34570240'
+  my_output_0: 34570240
+  my_output_1: 34570240

--- a/examples/spam_detection/01_provide_model.py
+++ b/examples/spam_detection/01_provide_model.py
@@ -12,15 +12,16 @@ import json
 import joblib
 import nada_numpy as na
 import py_nillion_client as nillion
+from common.utils import store_program, store_secrets
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
 from dotenv import load_dotenv
-from nada_ai.client import SklearnClient
-from nillion_python_helpers import create_nillion_client, create_payments_config
+from nillion_python_helpers import (create_nillion_client,
+                                    create_payments_config)
 from py_nillion_client import NodeKey, UserKey
 
-from common.utils import store_program, store_secrets
+from nada_ai.client import SklearnClient
 
 PARSER = argparse.ArgumentParser()
 PARSER.add_argument(

--- a/examples/spam_detection/02_run_inference.py
+++ b/examples/spam_detection/02_run_inference.py
@@ -14,14 +14,14 @@ import nada_numpy as na
 import nada_numpy.client as na_client
 import numpy as np
 import py_nillion_client as nillion
+from common.utils import compute, store_secret_array
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
 from dotenv import load_dotenv
-from nillion_python_helpers import create_nillion_client, create_payments_config
+from nillion_python_helpers import (create_nillion_client,
+                                    create_payments_config)
 from py_nillion_client import NodeKey, UserKey
-
-from common.utils import compute, store_secret_array
 
 PARSER = argparse.ArgumentParser()
 PARSER.add_argument(

--- a/examples/spam_detection/src/spam_detection.py
+++ b/examples/spam_detection/src/spam_detection.py
@@ -1,7 +1,8 @@
 import nada_numpy as na
 from config import DIM
-from nada_ai.linear_model import LogisticRegression
 from nada_dsl import Party
+
+from nada_ai.linear_model import LogisticRegression
 
 
 def nada_main():

--- a/examples/spam_detection/tests/spam_detection.yaml
+++ b/examples/spam_detection/tests/spam_detection.yaml
@@ -1,2007 +1,1005 @@
 program: spam_detection
 inputs:
-  my_input_81:
-    SecretInteger: '3'
-  my_input_417:
-    SecretInteger: '3'
-  my_input_168:
-    SecretInteger: '3'
-  my_input_75:
-    SecretInteger: '3'
-  my_model_coef_0_81:
-    SecretInteger: '3'
-  my_model_coef_0_194:
-    SecretInteger: '3'
-  my_model_coef_0_210:
-    SecretInteger: '3'
-  my_model_coef_0_108:
-    SecretInteger: '3'
-  my_model_coef_0_476:
-    SecretInteger: '3'
-  my_model_coef_0_182:
-    SecretInteger: '3'
-  my_input_236:
-    SecretInteger: '3'
-  my_input_13:
-    SecretInteger: '3'
-  my_model_coef_0_229:
-    SecretInteger: '3'
-  my_model_coef_0_147:
-    SecretInteger: '3'
-  my_input_468:
-    SecretInteger: '3'
-  my_model_coef_0_350:
-    SecretInteger: '3'
-  my_input_252:
-    SecretInteger: '3'
-  my_input_34:
-    SecretInteger: '3'
-  my_model_coef_0_212:
-    SecretInteger: '3'
-  my_input_330:
-    SecretInteger: '3'
-  my_input_240:
-    SecretInteger: '3'
-  my_input_133:
-    SecretInteger: '3'
-  my_model_coef_0_166:
-    SecretInteger: '3'
-  my_model_coef_0_174:
-    SecretInteger: '3'
-  my_model_coef_0_425:
-    SecretInteger: '3'
-  my_input_452:
-    SecretInteger: '3'
-  my_model_coef_0_423:
-    SecretInteger: '3'
-  my_model_coef_0_291:
-    SecretInteger: '3'
-  my_model_coef_0_359:
-    SecretInteger: '3'
-  my_model_coef_0_143:
-    SecretInteger: '3'
-  my_model_coef_0_94:
-    SecretInteger: '3'
-  my_model_coef_0_177:
-    SecretInteger: '3'
-  my_input_217:
-    SecretInteger: '3'
-  my_model_coef_0_80:
-    SecretInteger: '3'
-  my_input_336:
-    SecretInteger: '3'
-  my_input_472:
-    SecretInteger: '3'
-  my_model_coef_0_232:
-    SecretInteger: '3'
-  my_model_coef_0_274:
-    SecretInteger: '3'
-  my_model_coef_0_256:
-    SecretInteger: '3'
-  my_model_coef_0_368:
-    SecretInteger: '3'
-  my_input_47:
-    SecretInteger: '3'
-  my_input_79:
-    SecretInteger: '3'
-  my_input_409:
-    SecretInteger: '3'
-  my_model_coef_0_42:
-    SecretInteger: '3'
-  my_model_coef_0_262:
-    SecretInteger: '3'
-  my_model_coef_0_29:
-    SecretInteger: '3'
-  my_input_48:
-    SecretInteger: '3'
-  my_input_100:
-    SecretInteger: '3'
-  my_model_coef_0_483:
-    SecretInteger: '3'
-  my_input_372:
-    SecretInteger: '3'
-  my_input_276:
-    SecretInteger: '3'
-  my_input_221:
-    SecretInteger: '3'
-  my_input_349:
-    SecretInteger: '3'
-  my_model_coef_0_25:
-    SecretInteger: '3'
-  my_input_422:
-    SecretInteger: '3'
-  my_model_coef_0_379:
-    SecretInteger: '3'
-  my_input_329:
-    SecretInteger: '3'
-  my_input_482:
-    SecretInteger: '3'
-  my_model_coef_0_234:
-    SecretInteger: '3'
-  my_input_237:
-    SecretInteger: '3'
-  my_input_435:
-    SecretInteger: '3'
-  my_input_260:
-    SecretInteger: '3'
-  my_model_coef_0_400:
-    SecretInteger: '3'
-  my_model_coef_0_472:
-    SecretInteger: '3'
-  my_model_coef_0_96:
-    SecretInteger: '3'
-  my_model_coef_0_279:
-    SecretInteger: '3'
-  my_input_230:
-    SecretInteger: '3'
-  my_input_313:
-    SecretInteger: '3'
-  my_input_444:
-    SecretInteger: '3'
-  my_input_174:
-    SecretInteger: '3'
-  my_model_coef_0_236:
-    SecretInteger: '3'
-  my_input_122:
-    SecretInteger: '3'
-  my_input_461:
-    SecretInteger: '3'
-  my_input_1:
-    SecretInteger: '3'
-  my_input_314:
-    SecretInteger: '3'
-  my_input_325:
-    SecretInteger: '3'
-  my_model_coef_0_243:
-    SecretInteger: '3'
-  my_model_coef_0_383:
-    SecretInteger: '3'
-  my_input_3:
-    SecretInteger: '3'
-  my_input_195:
-    SecretInteger: '3'
-  my_input_473:
-    SecretInteger: '3'
-  my_input_464:
-    SecretInteger: '3'
-  my_input_300:
-    SecretInteger: '3'
-  my_model_coef_0_436:
-    SecretInteger: '3'
-  my_input_243:
-    SecretInteger: '3'
-  my_model_coef_0_192:
-    SecretInteger: '3'
-  my_model_coef_0_421:
-    SecretInteger: '3'
-  my_input_62:
-    SecretInteger: '3'
-  my_input_255:
-    SecretInteger: '3'
-  my_input_382:
-    SecretInteger: '3'
-  my_input_247:
-    SecretInteger: '3'
-  my_model_coef_0_116:
-    SecretInteger: '3'
-  my_input_242:
-    SecretInteger: '3'
-  my_model_coef_0_294:
-    SecretInteger: '3'
-  my_model_coef_0_59:
-    SecretInteger: '3'
-  my_model_coef_0_185:
-    SecretInteger: '3'
-  my_model_coef_0_390:
-    SecretInteger: '3'
-  my_model_coef_0_202:
-    SecretInteger: '3'
-  my_model_coef_0_304:
-    SecretInteger: '3'
-  my_model_coef_0_248:
-    SecretInteger: '3'
-  my_input_69:
-    SecretInteger: '3'
-  my_input_206:
-    SecretInteger: '3'
-  my_input_485:
-    SecretInteger: '3'
-  my_input_118:
-    SecretInteger: '3'
-  my_input_307:
-    SecretInteger: '3'
-  my_input_289:
-    SecretInteger: '3'
-  my_input_45:
-    SecretInteger: '3'
-  my_input_164:
-    SecretInteger: '3'
-  my_input_181:
-    SecretInteger: '3'
-  my_input_466:
-    SecretInteger: '3'
-  my_input_84:
-    SecretInteger: '3'
-  my_model_coef_0_208:
-    SecretInteger: '3'
-  my_input_395:
-    SecretInteger: '3'
-  my_input_127:
-    SecretInteger: '3'
-  my_input_29:
-    SecretInteger: '3'
-  my_input_144:
-    SecretInteger: '3'
-  my_input_326:
-    SecretInteger: '3'
-  my_input_495:
-    SecretInteger: '3'
-  my_input_191:
-    SecretInteger: '3'
-  my_model_coef_0_67:
-    SecretInteger: '3'
-  my_model_coef_0_394:
-    SecretInteger: '3'
-  my_input_319:
-    SecretInteger: '3'
-  my_input_126:
-    SecretInteger: '3'
-  my_input_431:
-    SecretInteger: '3'
-  my_model_coef_0_388:
-    SecretInteger: '3'
-  my_model_coef_0_227:
-    SecretInteger: '3'
-  my_input_15:
-    SecretInteger: '3'
-  my_input_128:
-    SecretInteger: '3'
-  my_input_445:
-    SecretInteger: '3'
-  my_input_59:
-    SecretInteger: '3'
-  my_input_404:
-    SecretInteger: '3'
-  my_input_158:
-    SecretInteger: '3'
-  my_model_coef_0_470:
-    SecretInteger: '3'
-  my_model_coef_0_137:
-    SecretInteger: '3'
-  my_model_coef_0_33:
-    SecretInteger: '3'
-  my_input_183:
-    SecretInteger: '3'
-  my_model_coef_0_395:
-    SecretInteger: '3'
-  my_input_323:
-    SecretInteger: '3'
-  my_input_327:
-    SecretInteger: '3'
-  my_input_113:
-    SecretInteger: '3'
-  my_model_coef_0_498:
-    SecretInteger: '3'
-  my_input_385:
-    SecretInteger: '3'
-  my_input_362:
-    SecretInteger: '3'
-  my_input_92:
-    SecretInteger: '3'
-  my_model_coef_0_333:
-    SecretInteger: '3'
-  my_input_49:
-    SecretInteger: '3'
-  my_model_coef_0_241:
-    SecretInteger: '3'
-  my_model_coef_0_361:
-    SecretInteger: '3'
-  my_model_coef_0_381:
-    SecretInteger: '3'
-  my_model_coef_0_409:
-    SecretInteger: '3'
-  my_input_72:
-    SecretInteger: '3'
-  my_input_123:
-    SecretInteger: '3'
-  my_model_coef_0_64:
-    SecretInteger: '3'
-  my_input_170:
-    SecretInteger: '3'
-  my_input_328:
-    SecretInteger: '3'
-  my_input_250:
-    SecretInteger: '3'
-  my_input_341:
-    SecretInteger: '3'
-  my_input_303:
-    SecretInteger: '3'
-  my_input_426:
-    SecretInteger: '3'
-  my_model_coef_0_131:
-    SecretInteger: '3'
-  my_input_420:
-    SecretInteger: '3'
-  my_model_coef_0_153:
-    SecretInteger: '3'
-  my_model_coef_0_403:
-    SecretInteger: '3'
-  my_input_67:
-    SecretInteger: '3'
-  my_input_321:
-    SecretInteger: '3'
-  my_model_coef_0_112:
-    SecretInteger: '3'
-  my_input_486:
-    SecretInteger: '3'
-  my_model_coef_0_6:
-    SecretInteger: '3'
-  my_model_coef_0_357:
-    SecretInteger: '3'
-  my_input_399:
-    SecretInteger: '3'
-  my_input_432:
-    SecretInteger: '3'
-  my_input_8:
-    SecretInteger: '3'
-  my_model_coef_0_485:
-    SecretInteger: '3'
-  my_input_407:
-    SecretInteger: '3'
-  my_input_22:
-    SecretInteger: '3'
-  my_model_coef_0_306:
-    SecretInteger: '3'
-  my_model_coef_0_163:
-    SecretInteger: '3'
-  my_input_196:
-    SecretInteger: '3'
-  my_input_364:
-    SecretInteger: '3'
-  my_model_coef_0_341:
-    SecretInteger: '3'
-  my_input_350:
-    SecretInteger: '3'
-  my_input_377:
-    SecretInteger: '3'
-  my_input_454:
-    SecretInteger: '3'
-  my_input_458:
-    SecretInteger: '3'
-  my_model_coef_0_167:
-    SecretInteger: '3'
-  my_model_coef_0_430:
-    SecretInteger: '3'
-  my_model_coef_0_129:
-    SecretInteger: '3'
-  my_input_400:
-    SecretInteger: '3'
-  my_model_coef_0_41:
-    SecretInteger: '3'
-  my_input_265:
-    SecretInteger: '3'
-  my_model_coef_0_134:
-    SecretInteger: '3'
-  my_model_coef_0_82:
-    SecretInteger: '3'
-  my_model_coef_0_56:
-    SecretInteger: '3'
-  my_input_38:
-    SecretInteger: '3'
-  my_input_103:
-    SecretInteger: '3'
-  my_model_coef_0_0:
-    SecretInteger: '3'
-  my_model_coef_0_260:
-    SecretInteger: '3'
-  my_model_coef_0_362:
-    SecretInteger: '3'
-  my_input_443:
-    SecretInteger: '3'
-  my_input_306:
-    SecretInteger: '3'
-  my_model_coef_0_441:
-    SecretInteger: '3'
-  my_model_coef_0_209:
-    SecretInteger: '3'
-  my_model_coef_0_141:
-    SecretInteger: '3'
-  my_model_coef_0_217:
-    SecretInteger: '3'
-  my_model_coef_0_4:
-    SecretInteger: '3'
-  my_model_coef_0_161:
-    SecretInteger: '3'
-  my_model_coef_0_481:
-    SecretInteger: '3'
-  my_input_119:
-    SecretInteger: '3'
-  my_model_coef_0_204:
-    SecretInteger: '3'
-  my_model_intercept_0:
-    SecretInteger: '3'
-  my_input_177:
-    SecretInteger: '3'
-  my_input_86:
-    SecretInteger: '3'
-  my_model_coef_0_424:
-    SecretInteger: '3'
-  my_model_coef_0_355:
-    SecretInteger: '3'
-  my_model_coef_0_55:
-    SecretInteger: '3'
-  my_input_231:
-    SecretInteger: '3'
-  my_input_74:
-    SecretInteger: '3'
-  my_model_coef_0_432:
-    SecretInteger: '3'
-  my_input_455:
-    SecretInteger: '3'
-  my_model_coef_0_17:
-    SecretInteger: '3'
-  my_model_coef_0_119:
-    SecretInteger: '3'
-  my_input_156:
-    SecretInteger: '3'
-  my_input_190:
-    SecretInteger: '3'
-  my_input_381:
-    SecretInteger: '3'
-  my_input_421:
-    SecretInteger: '3'
-  my_model_coef_0_447:
-    SecretInteger: '3'
-  my_input_180:
-    SecretInteger: '3'
-  my_input_489:
-    SecretInteger: '3'
-  my_model_coef_0_363:
-    SecretInteger: '3'
-  my_model_coef_0_440:
-    SecretInteger: '3'
-  my_input_264:
-    SecretInteger: '3'
-  my_model_coef_0_101:
-    SecretInteger: '3'
-  my_model_coef_0_69:
-    SecretInteger: '3'
-  my_model_coef_0_246:
-    SecretInteger: '3'
-  my_model_coef_0_135:
-    SecretInteger: '3'
-  my_input_499:
-    SecretInteger: '3'
-  my_model_coef_0_346:
-    SecretInteger: '3'
-  my_input_412:
-    SecretInteger: '3'
-  my_input_441:
-    SecretInteger: '3'
-  my_model_coef_0_272:
-    SecretInteger: '3'
-  my_input_32:
-    SecretInteger: '3'
-  my_model_coef_0_251:
-    SecretInteger: '3'
-  my_input_16:
-    SecretInteger: '3'
-  my_model_coef_0_254:
-    SecretInteger: '3'
-  my_input_7:
-    SecretInteger: '3'
-  my_input_384:
-    SecretInteger: '3'
-  my_model_coef_0_392:
-    SecretInteger: '3'
-  my_model_coef_0_62:
-    SecretInteger: '3'
-  my_input_90:
-    SecretInteger: '3'
-  my_input_194:
-    SecretInteger: '3'
-  my_model_coef_0_468:
-    SecretInteger: '3'
-  my_input_366:
-    SecretInteger: '3'
-  my_input_405:
-    SecretInteger: '3'
-  my_model_coef_0_13:
-    SecretInteger: '3'
-  my_model_coef_0_159:
-    SecretInteger: '3'
-  my_input_424:
-    SecretInteger: '3'
-  my_input_254:
-    SecretInteger: '3'
-  my_model_coef_0_428:
-    SecretInteger: '3'
-  my_model_coef_0_21:
-    SecretInteger: '3'
-  my_input_226:
-    SecretInteger: '3'
-  my_model_coef_0_258:
-    SecretInteger: '3'
-  my_input_310:
-    SecretInteger: '3'
-  my_model_coef_0_426:
-    SecretInteger: '3'
-  my_model_coef_0_477:
-    SecretInteger: '3'
-  my_model_coef_0_24:
-    SecretInteger: '3'
-  my_model_coef_0_85:
-    SecretInteger: '3'
-  my_model_coef_0_37:
-    SecretInteger: '3'
-  my_model_coef_0_145:
-    SecretInteger: '3'
-  my_input_160:
-    SecretInteger: '3'
-  my_input_256:
-    SecretInteger: '3'
-  my_model_coef_0_91:
-    SecretInteger: '3'
-  my_model_coef_0_399:
-    SecretInteger: '3'
-  my_model_coef_0_309:
-    SecretInteger: '3'
-  my_model_coef_0_9:
-    SecretInteger: '3'
-  my_model_coef_0_367:
-    SecretInteger: '3'
-  my_model_coef_0_326:
-    SecretInteger: '3'
-  my_model_coef_0_329:
-    SecretInteger: '3'
-  my_input_296:
-    SecretInteger: '3'
-  my_input_484:
-    SecretInteger: '3'
-  my_input_200:
-    SecretInteger: '3'
-  my_model_coef_0_83:
-    SecretInteger: '3'
-  my_input_462:
-    SecretInteger: '3'
-  my_input_277:
-    SecretInteger: '3'
-  my_model_coef_0_238:
-    SecretInteger: '3'
-  my_model_coef_0_444:
-    SecretInteger: '3'
-  my_model_coef_0_358:
-    SecretInteger: '3'
-  my_model_coef_0_158:
-    SecretInteger: '3'
-  my_input_390:
-    SecretInteger: '3'
-  my_model_coef_0_307:
-    SecretInteger: '3'
-  my_model_coef_0_493:
-    SecretInteger: '3'
-  my_model_coef_0_323:
-    SecretInteger: '3'
-  my_input_374:
-    SecretInteger: '3'
-  my_input_469:
-    SecretInteger: '3'
-  my_model_coef_0_488:
-    SecretInteger: '3'
-  my_model_coef_0_213:
-    SecretInteger: '3'
-  my_input_56:
-    SecretInteger: '3'
-  my_model_coef_0_79:
-    SecretInteger: '3'
-  my_input_159:
-    SecretInteger: '3'
-  my_model_coef_0_429:
-    SecretInteger: '3'
-  my_input_293:
-    SecretInteger: '3'
-  my_input_167:
-    SecretInteger: '3'
-  my_input_375:
-    SecretInteger: '3'
-  my_model_coef_0_136:
-    SecretInteger: '3'
-  my_input_43:
-    SecretInteger: '3'
-  my_model_coef_0_157:
-    SecretInteger: '3'
-  my_input_24:
-    SecretInteger: '3'
-  my_input_5:
-    SecretInteger: '3'
-  my_input_450:
-    SecretInteger: '3'
-  my_input_42:
-    SecretInteger: '3'
-  my_model_coef_0_76:
-    SecretInteger: '3'
-  my_model_coef_0_464:
-    SecretInteger: '3'
-  my_input_19:
-    SecretInteger: '3'
-  my_model_coef_0_198:
-    SecretInteger: '3'
-  my_input_249:
-    SecretInteger: '3'
-  my_input_493:
-    SecretInteger: '3'
-  my_model_coef_0_288:
-    SecretInteger: '3'
-  my_input_302:
-    SecretInteger: '3'
-  my_model_coef_0_150:
-    SecretInteger: '3'
-  my_input_204:
-    SecretInteger: '3'
-  my_input_60:
-    SecretInteger: '3'
-  my_input_220:
-    SecretInteger: '3'
-  my_model_coef_0_280:
-    SecretInteger: '3'
-  my_model_coef_0_494:
-    SecretInteger: '3'
-  my_model_coef_0_16:
-    SecretInteger: '3'
-  my_input_322:
-    SecretInteger: '3'
-  my_model_coef_0_268:
-    SecretInteger: '3'
-  my_model_coef_0_489:
-    SecretInteger: '3'
-  my_model_coef_0_442:
-    SecretInteger: '3'
-  my_model_coef_0_374:
-    SecretInteger: '3'
-  my_model_coef_0_478:
-    SecretInteger: '3'
-  my_input_298:
-    SecretInteger: '3'
-  my_input_483:
-    SecretInteger: '3'
-  my_input_267:
-    SecretInteger: '3'
-  my_model_coef_0_73:
-    SecretInteger: '3'
-  my_input_368:
-    SecretInteger: '3'
-  my_input_207:
-    SecretInteger: '3'
-  my_model_coef_0_220:
-    SecretInteger: '3'
-  my_input_318:
-    SecretInteger: '3'
-  my_model_coef_0_492:
-    SecretInteger: '3'
-  my_input_161:
-    SecretInteger: '3'
-  my_model_coef_0_180:
-    SecretInteger: '3'
-  my_model_coef_0_371:
-    SecretInteger: '3'
-  my_model_coef_0_87:
-    SecretInteger: '3'
-  my_model_coef_0_90:
-    SecretInteger: '3'
-  my_model_coef_0_148:
-    SecretInteger: '3'
-  my_model_coef_0_342:
-    SecretInteger: '3'
-  my_model_coef_0_43:
-    SecretInteger: '3'
-  my_input_73:
-    SecretInteger: '3'
-  my_input_339:
-    SecretInteger: '3'
-  my_model_coef_0_179:
-    SecretInteger: '3'
-  my_input_338:
-    SecretInteger: '3'
-  my_input_434:
-    SecretInteger: '3'
-  my_input_475:
-    SecretInteger: '3'
-  my_model_coef_0_107:
-    SecretInteger: '3'
-  my_model_coef_0_211:
-    SecretInteger: '3'
-  my_model_coef_0_473:
-    SecretInteger: '3'
-  my_input_274:
-    SecretInteger: '3'
-  my_input_447:
-    SecretInteger: '3'
-  my_input_175:
-    SecretInteger: '3'
-  my_input_55:
-    SecretInteger: '3'
-  my_model_coef_0_171:
-    SecretInteger: '3'
-  my_input_392:
-    SecretInteger: '3'
-  my_model_coef_0_216:
-    SecretInteger: '3'
-  my_input_145:
-    SecretInteger: '3'
-  my_input_227:
-    SecretInteger: '3'
-  my_model_coef_0_226:
-    SecretInteger: '3'
-  my_model_coef_0_31:
-    SecretInteger: '3'
-  my_input_98:
-    SecretInteger: '3'
-  my_input_106:
-    SecretInteger: '3'
-  my_input_216:
-    SecretInteger: '3'
-  my_model_coef_0_126:
-    SecretInteger: '3'
-  my_input_134:
-    SecretInteger: '3'
-  my_model_coef_0_102:
-    SecretInteger: '3'
-  my_input_324:
-    SecretInteger: '3'
-  my_input_162:
-    SecretInteger: '3'
-  my_input_121:
-    SecretInteger: '3'
-  my_input_71:
-    SecretInteger: '3'
-  my_input_491:
-    SecretInteger: '3'
-  my_model_coef_0_58:
-    SecretInteger: '3'
-  my_input_269:
-    SecretInteger: '3'
-  my_input_383:
-    SecretInteger: '3'
-  my_model_coef_0_303:
-    SecretInteger: '3'
-  my_model_coef_0_120:
-    SecretInteger: '3'
-  my_input_150:
-    SecretInteger: '3'
-  my_model_coef_0_32:
-    SecretInteger: '3'
-  my_model_coef_0_100:
-    SecretInteger: '3'
-  my_input_52:
-    SecretInteger: '3'
-  my_model_coef_0_397:
-    SecretInteger: '3'
-  my_model_coef_0_181:
-    SecretInteger: '3'
-  my_input_287:
-    SecretInteger: '3'
-  my_model_coef_0_263:
-    SecretInteger: '3'
-  my_model_coef_0_360:
-    SecretInteger: '3'
-  my_input_110:
-    SecretInteger: '3'
-  my_input_288:
-    SecretInteger: '3'
-  my_input_305:
-    SecretInteger: '3'
-  my_input_453:
-    SecretInteger: '3'
-  my_input_232:
-    SecretInteger: '3'
-  my_input_474:
-    SecretInteger: '3'
-  my_model_coef_0_348:
-    SecretInteger: '3'
-  my_model_coef_0_452:
-    SecretInteger: '3'
-  my_model_coef_0_352:
-    SecretInteger: '3'
-  my_input_4:
-    SecretInteger: '3'
-  my_input_31:
-    SecretInteger: '3'
-  my_model_coef_0_281:
-    SecretInteger: '3'
-  my_input_365:
-    SecretInteger: '3'
-  my_model_coef_0_103:
-    SecretInteger: '3'
-  my_model_coef_0_175:
-    SecretInteger: '3'
-  my_model_coef_0_138:
-    SecretInteger: '3'
-  my_model_coef_0_40:
-    SecretInteger: '3'
-  my_model_coef_0_230:
-    SecretInteger: '3'
-  my_model_coef_0_193:
-    SecretInteger: '3'
-  my_model_coef_0_200:
-    SecretInteger: '3'
-  my_input_89:
-    SecretInteger: '3'
-  my_model_coef_0_427:
-    SecretInteger: '3'
-  my_input_480:
-    SecretInteger: '3'
-  my_input_253:
-    SecretInteger: '3'
-  my_model_coef_0_11:
-    SecretInteger: '3'
-  my_model_coef_0_12:
-    SecretInteger: '3'
-  my_model_coef_0_113:
-    SecretInteger: '3'
-  my_model_coef_0_438:
-    SecretInteger: '3'
-  my_model_coef_0_247:
-    SecretInteger: '3'
-  my_input_284:
-    SecretInteger: '3'
-  my_input_137:
-    SecretInteger: '3'
-  my_model_coef_0_283:
-    SecretInteger: '3'
-  my_model_coef_0_420:
-    SecretInteger: '3'
-  my_input_176:
-    SecretInteger: '3'
-  my_model_coef_0_223:
-    SecretInteger: '3'
-  my_model_coef_0_435:
-    SecretInteger: '3'
-  my_input_244:
-    SecretInteger: '3'
-  my_input_477:
-    SecretInteger: '3'
-  my_input_471:
-    SecretInteger: '3'
-  my_input_114:
-    SecretInteger: '3'
-  my_input_233:
-    SecretInteger: '3'
-  my_model_coef_0_151:
-    SecretInteger: '3'
-  my_model_coef_0_253:
-    SecretInteger: '3'
-  my_model_coef_0_264:
-    SecretInteger: '3'
-  my_model_coef_0_142:
-    SecretInteger: '3'
-  my_model_coef_0_391:
-    SecretInteger: '3'
-  my_model_coef_0_337:
-    SecretInteger: '3'
-  my_input_369:
-    SecretInteger: '3'
-  my_model_coef_0_284:
-    SecretInteger: '3'
-  my_model_coef_0_314:
-    SecretInteger: '3'
-  my_model_coef_0_28:
-    SecretInteger: '3'
-  my_model_coef_0_334:
-    SecretInteger: '3'
-  my_input_225:
-    SecretInteger: '3'
-  my_input_358:
-    SecretInteger: '3'
-  my_input_460:
-    SecretInteger: '3'
-  my_model_coef_0_45:
-    SecretInteger: '3'
-  my_model_coef_0_389:
-    SecretInteger: '3'
-  my_input_406:
-    SecretInteger: '3'
-  my_input_487:
-    SecretInteger: '3'
-  my_model_coef_0_114:
-    SecretInteger: '3'
-  my_model_coef_0_463:
-    SecretInteger: '3'
-  my_model_coef_0_110:
-    SecretInteger: '3'
-  my_input_299:
-    SecretInteger: '3'
-  my_input_488:
-    SecretInteger: '3'
-  my_input_352:
-    SecretInteger: '3'
-  my_model_coef_0_313:
-    SecretInteger: '3'
-  my_model_coef_0_376:
-    SecretInteger: '3'
-  my_model_coef_0_164:
-    SecretInteger: '3'
-  my_model_coef_0_414:
-    SecretInteger: '3'
-  my_model_coef_0_22:
-    SecretInteger: '3'
-  my_input_348:
-    SecretInteger: '3'
-  my_input_315:
-    SecretInteger: '3'
-  my_input_189:
-    SecretInteger: '3'
-  my_input_347:
-    SecretInteger: '3'
-  my_input_241:
-    SecretInteger: '3'
-  my_input_41:
-    SecretInteger: '3'
-  my_model_coef_0_235:
-    SecretInteger: '3'
-  my_model_coef_0_244:
-    SecretInteger: '3'
-  my_model_coef_0_378:
-    SecretInteger: '3'
-  my_model_coef_0_401:
-    SecretInteger: '3'
-  my_input_140:
-    SecretInteger: '3'
-  my_input_463:
-    SecretInteger: '3'
-  my_model_coef_0_340:
-    SecretInteger: '3'
-  my_model_coef_0_205:
-    SecretInteger: '3'
-  my_model_coef_0_127:
-    SecretInteger: '3'
-  my_model_coef_0_191:
-    SecretInteger: '3'
-  my_input_96:
-    SecretInteger: '3'
-  my_input_146:
-    SecretInteger: '3'
-  my_input_391:
-    SecretInteger: '3'
-  my_model_coef_0_15:
-    SecretInteger: '3'
-  my_model_coef_0_201:
-    SecretInteger: '3'
-  my_input_355:
-    SecretInteger: '3'
-  my_input_139:
-    SecretInteger: '3'
-  my_input_270:
-    SecretInteger: '3'
-  my_model_coef_0_20:
-    SecretInteger: '3'
-  my_input_414:
-    SecretInteger: '3'
-  my_model_coef_0_117:
-    SecretInteger: '3'
-  my_input_428:
-    SecretInteger: '3'
-  my_input_494:
-    SecretInteger: '3'
-  my_model_coef_0_168:
-    SecretInteger: '3'
-  my_input_266:
-    SecretInteger: '3'
-  my_input_492:
-    SecretInteger: '3'
-  my_input_94:
-    SecretInteger: '3'
-  my_input_102:
-    SecretInteger: '3'
-  my_model_coef_0_365:
-    SecretInteger: '3'
-  my_input_212:
-    SecretInteger: '3'
-  my_input_205:
-    SecretInteger: '3'
-  my_input_213:
-    SecretInteger: '3'
-  my_model_coef_0_39:
-    SecretInteger: '3'
-  my_model_coef_0_404:
-    SecretInteger: '3'
-  my_input_416:
-    SecretInteger: '3'
-  my_input_258:
-    SecretInteger: '3'
-  my_model_coef_0_245:
-    SecretInteger: '3'
-  my_input_411:
-    SecretInteger: '3'
-  my_input_278:
-    SecretInteger: '3'
-  my_model_coef_0_311:
-    SecretInteger: '3'
-  my_input_23:
-    SecretInteger: '3'
-  my_input_282:
-    SecretInteger: '3'
-  my_input_342:
-    SecretInteger: '3'
-  my_model_coef_0_57:
-    SecretInteger: '3'
-  my_model_coef_0_23:
-    SecretInteger: '3'
-  my_input_496:
-    SecretInteger: '3'
-  my_input_173:
-    SecretInteger: '3'
-  my_input_82:
-    SecretInteger: '3'
-  my_model_coef_0_88:
-    SecretInteger: '3'
-  my_input_87:
-    SecretInteger: '3'
-  my_model_coef_0_118:
-    SecretInteger: '3'
-  my_input_138:
-    SecretInteger: '3'
-  my_input_179:
-    SecretInteger: '3'
-  my_input_120:
-    SecretInteger: '3'
-  my_model_coef_0_316:
-    SecretInteger: '3'
-  my_model_coef_0_240:
-    SecretInteger: '3'
-  my_model_coef_0_351:
-    SecretInteger: '3'
-  my_input_245:
-    SecretInteger: '3'
-  my_model_coef_0_349:
-    SecretInteger: '3'
-  my_model_coef_0_86:
-    SecretInteger: '3'
-  my_input_178:
-    SecretInteger: '3'
-  my_model_coef_0_336:
-    SecretInteger: '3'
-  my_input_185:
-    SecretInteger: '3'
-  my_input_187:
-    SecretInteger: '3'
-  my_input_11:
-    SecretInteger: '3'
-  my_model_coef_0_275:
-    SecretInteger: '3'
-  my_model_coef_0_54:
-    SecretInteger: '3'
-  my_model_coef_0_5:
-    SecretInteger: '3'
-  my_model_coef_0_335:
-    SecretInteger: '3'
-  my_input_413:
-    SecretInteger: '3'
-  my_input_26:
-    SecretInteger: '3'
-  my_model_coef_0_231:
-    SecretInteger: '3'
-  my_model_coef_0_486:
-    SecretInteger: '3'
-  my_input_125:
-    SecretInteger: '3'
-  my_model_coef_0_225:
-    SecretInteger: '3'
-  my_model_coef_0_295:
-    SecretInteger: '3'
-  my_model_coef_0_282:
-    SecretInteger: '3'
-  my_model_coef_0_289:
-    SecretInteger: '3'
-  my_model_coef_0_95:
-    SecretInteger: '3'
-  my_model_coef_0_411:
-    SecretInteger: '3'
-  my_input_229:
-    SecretInteger: '3'
-  my_input_165:
-    SecretInteger: '3'
-  my_model_coef_0_27:
-    SecretInteger: '3'
-  my_model_coef_0_250:
-    SecretInteger: '3'
-  my_input_223:
-    SecretInteger: '3'
-  my_input_6:
-    SecretInteger: '3'
-  my_input_63:
-    SecretInteger: '3'
-  my_model_coef_0_152:
-    SecretInteger: '3'
-  my_input_188:
-    SecretInteger: '3'
-  my_input_333:
-    SecretInteger: '3'
-  my_model_coef_0_277:
-    SecretInteger: '3'
-  my_model_coef_0_178:
-    SecretInteger: '3'
-  my_input_109:
-    SecretInteger: '3'
-  my_model_coef_0_330:
-    SecretInteger: '3'
-  my_model_coef_0_386:
-    SecretInteger: '3'
-  my_input_169:
-    SecretInteger: '3'
-  my_model_coef_0_154:
-    SecretInteger: '3'
-  my_model_coef_0_160:
-    SecretInteger: '3'
-  my_model_coef_0_99:
-    SecretInteger: '3'
-  my_input_294:
-    SecretInteger: '3'
-  my_model_coef_0_451:
-    SecretInteger: '3'
-  my_input_280:
-    SecretInteger: '3'
-  my_model_coef_0_398:
-    SecretInteger: '3'
-  my_input_394:
-    SecretInteger: '3'
-  my_model_coef_0_497:
-    SecretInteger: '3'
-  my_input_286:
-    SecretInteger: '3'
-  my_input_387:
-    SecretInteger: '3'
-  my_input_199:
-    SecretInteger: '3'
-  my_model_coef_0_139:
-    SecretInteger: '3'
-  my_model_coef_0_259:
-    SecretInteger: '3'
-  my_model_coef_0_132:
-    SecretInteger: '3'
-  my_model_coef_0_130:
-    SecretInteger: '3'
-  my_model_coef_0_2:
-    SecretInteger: '3'
-  my_model_coef_0_125:
-    SecretInteger: '3'
-  my_model_coef_0_215:
-    SecretInteger: '3'
-  my_model_coef_0_465:
-    SecretInteger: '3'
-  my_model_coef_0_495:
-    SecretInteger: '3'
-  my_model_coef_0_77:
-    SecretInteger: '3'
-  my_model_coef_0_122:
-    SecretInteger: '3'
-  my_model_coef_0_366:
-    SecretInteger: '3'
-  my_model_coef_0_203:
-    SecretInteger: '3'
-  my_model_coef_0_74:
-    SecretInteger: '3'
-  my_model_coef_0_292:
-    SecretInteger: '3'
-  my_input_53:
-    SecretInteger: '3'
-  my_model_coef_0_300:
-    SecretInteger: '3'
-  my_model_coef_0_298:
-    SecretInteger: '3'
-  my_input_39:
-    SecretInteger: '3'
-  my_input_46:
-    SecretInteger: '3'
-  my_input_136:
-    SecretInteger: '3'
-  my_input_9:
-    SecretInteger: '3'
-  my_input_83:
-    SecretInteger: '3'
-  my_input_478:
-    SecretInteger: '3'
-  my_model_coef_0_53:
-    SecretInteger: '3'
-  my_model_coef_0_199:
-    SecretInteger: '3'
-  my_model_coef_0_458:
-    SecretInteger: '3'
-  my_model_coef_0_387:
-    SecretInteger: '3'
-  my_model_coef_0_310:
-    SecretInteger: '3'
-  my_input_272:
-    SecretInteger: '3'
-  my_model_coef_0_273:
-    SecretInteger: '3'
-  my_model_coef_0_93:
-    SecretInteger: '3'
-  my_model_coef_0_70:
-    SecretInteger: '3'
-  my_input_50:
-    SecretInteger: '3'
-  my_input_353:
-    SecretInteger: '3'
-  my_input_442:
-    SecretInteger: '3'
-  my_input_379:
-    SecretInteger: '3'
-  my_model_coef_0_434:
-    SecretInteger: '3'
-  my_input_93:
-    SecretInteger: '3'
-  my_input_203:
-    SecretInteger: '3'
-  my_input_64:
-    SecretInteger: '3'
-  my_model_coef_0_499:
-    SecretInteger: '3'
-  my_input_142:
-    SecretInteger: '3'
-  my_input_182:
-    SecretInteger: '3'
-  my_input_115:
-    SecretInteger: '3'
-  my_input_117:
-    SecretInteger: '3'
-  my_model_coef_0_104:
-    SecretInteger: '3'
-  my_model_coef_0_156:
-    SecretInteger: '3'
-  my_model_coef_0_293:
-    SecretInteger: '3'
-  my_input_155:
-    SecretInteger: '3'
-  my_input_148:
-    SecretInteger: '3'
-  my_input_476:
-    SecretInteger: '3'
-  my_model_coef_0_408:
-    SecretInteger: '3'
-  my_model_coef_0_322:
-    SecretInteger: '3'
-  my_model_coef_0_433:
-    SecretInteger: '3'
-  my_model_coef_0_97:
-    SecretInteger: '3'
-  my_input_116:
-    SecretInteger: '3'
-  my_model_coef_0_186:
-    SecretInteger: '3'
-  my_model_coef_0_439:
-    SecretInteger: '3'
-  my_input_153:
-    SecretInteger: '3'
-  my_model_coef_0_187:
-    SecretInteger: '3'
-  my_input_248:
-    SecretInteger: '3'
-  my_input_292:
-    SecretInteger: '3'
-  my_input_25:
-    SecretInteger: '3'
-  my_model_coef_0_105:
-    SecretInteger: '3'
-  my_input_135:
-    SecretInteger: '3'
-  my_input_427:
-    SecretInteger: '3'
-  my_input_85:
-    SecretInteger: '3'
-  my_model_coef_0_422:
-    SecretInteger: '3'
-  my_model_coef_0_89:
-    SecretInteger: '3'
-  my_input_147:
-    SecretInteger: '3'
-  my_input_268:
-    SecretInteger: '3'
-  my_model_coef_0_384:
-    SecretInteger: '3'
-  my_model_coef_0_480:
-    SecretInteger: '3'
-  my_model_coef_0_308:
-    SecretInteger: '3'
-  my_model_coef_0_354:
-    SecretInteger: '3'
-  my_input_132:
-    SecretInteger: '3'
-  my_input_202:
-    SecretInteger: '3'
-  my_input_357:
-    SecretInteger: '3'
-  my_input_320:
-    SecretInteger: '3'
-  my_input_209:
-    SecretInteger: '3'
-  my_model_coef_0_172:
-    SecretInteger: '3'
-  my_input_66:
-    SecretInteger: '3'
-  my_input_124:
-    SecretInteger: '3'
-  my_input_373:
-    SecretInteger: '3'
-  my_model_coef_0_479:
-    SecretInteger: '3'
-  my_model_coef_0_146:
-    SecretInteger: '3'
-  my_model_coef_0_466:
-    SecretInteger: '3'
-  my_model_coef_0_8:
-    SecretInteger: '3'
-  my_input_356:
-    SecretInteger: '3'
-  my_input_371:
-    SecretInteger: '3'
-  my_input_378:
-    SecretInteger: '3'
-  my_model_coef_0_121:
-    SecretInteger: '3'
-  my_model_coef_0_170:
-    SecretInteger: '3'
-  my_input_470:
-    SecretInteger: '3'
-  my_model_coef_0_325:
-    SecretInteger: '3'
-  my_model_coef_0_457:
-    SecretInteger: '3'
-  my_input_101:
-    SecretInteger: '3'
-  my_model_coef_0_52:
-    SecretInteger: '3'
-  my_model_coef_0_270:
-    SecretInteger: '3'
-  my_model_coef_0_26:
-    SecretInteger: '3'
-  my_model_coef_0_290:
-    SecretInteger: '3'
-  my_input_498:
-    SecretInteger: '3'
-  my_model_coef_0_165:
-    SecretInteger: '3'
-  my_input_449:
-    SecretInteger: '3'
-  my_input_376:
-    SecretInteger: '3'
-  my_model_coef_0_339:
-    SecretInteger: '3'
-  my_input_316:
-    SecretInteger: '3'
-  my_model_coef_0_188:
-    SecretInteger: '3'
-  my_model_coef_0_413:
-    SecretInteger: '3'
-  my_model_coef_0_338:
-    SecretInteger: '3'
-  my_model_coef_0_10:
-    SecretInteger: '3'
-  my_model_coef_0_469:
-    SecretInteger: '3'
-  my_model_coef_0_276:
-    SecretInteger: '3'
-  my_model_coef_0_155:
-    SecretInteger: '3'
-  my_model_coef_0_115:
-    SecretInteger: '3'
-  my_input_186:
-    SecretInteger: '3'
-  my_input_446:
-    SecretInteger: '3'
-  my_model_coef_0_173:
-    SecretInteger: '3'
-  my_model_coef_0_405:
-    SecretInteger: '3'
-  my_input_291:
-    SecretInteger: '3'
-  my_model_coef_0_321:
-    SecretInteger: '3'
-  my_model_coef_0_38:
-    SecretInteger: '3'
-  my_model_coef_0_176:
-    SecretInteger: '3'
-  my_model_coef_0_49:
-    SecretInteger: '3'
-  my_model_coef_0_385:
-    SecretInteger: '3'
-  my_model_coef_0_267:
-    SecretInteger: '3'
-  my_model_coef_0_14:
-    SecretInteger: '3'
-  my_model_coef_0_48:
-    SecretInteger: '3'
-  my_model_coef_0_312:
-    SecretInteger: '3'
-  my_input_430:
-    SecretInteger: '3'
-  my_model_coef_0_373:
-    SecretInteger: '3'
-  my_model_coef_0_443:
-    SecretInteger: '3'
-  my_model_coef_0_327:
-    SecretInteger: '3'
-  my_model_coef_0_453:
-    SecretInteger: '3'
-  my_input_35:
-    SecretInteger: '3'
-  my_input_208:
-    SecretInteger: '3'
-  my_input_228:
-    SecretInteger: '3'
-  my_model_coef_0_302:
-    SecretInteger: '3'
-  my_model_coef_0_491:
-    SecretInteger: '3'
-  my_model_coef_0_34:
-    SecretInteger: '3'
-  my_model_coef_0_305:
-    SecretInteger: '3'
-  my_model_coef_0_320:
-    SecretInteger: '3'
-  my_input_380:
-    SecretInteger: '3'
-  my_model_coef_0_47:
-    SecretInteger: '3'
-  my_input_419:
-    SecretInteger: '3'
-  my_model_coef_0_484:
-    SecretInteger: '3'
-  my_input_70:
-    SecretInteger: '3'
-  my_input_218:
-    SecretInteger: '3'
-  my_model_coef_0_474:
-    SecretInteger: '3'
-  my_input_257:
-    SecretInteger: '3'
-  my_input_361:
-    SecretInteger: '3'
-  my_input_219:
-    SecretInteger: '3'
-  my_model_coef_0_331:
-    SecretInteger: '3'
-  my_input_37:
-    SecretInteger: '3'
-  my_input_456:
-    SecretInteger: '3'
-  my_model_coef_0_252:
-    SecretInteger: '3'
-  my_input_57:
-    SecretInteger: '3'
-  my_input_91:
-    SecretInteger: '3'
-  my_model_coef_0_446:
-    SecretInteger: '3'
-  my_model_coef_0_184:
-    SecretInteger: '3'
-  my_input_354:
-    SecretInteger: '3'
-  my_model_coef_0_410:
-    SecretInteger: '3'
-  my_input_10:
-    SecretInteger: '3'
-  my_input_172:
-    SecretInteger: '3'
-  my_model_coef_0_460:
-    SecretInteger: '3'
-  my_model_coef_0_449:
-    SecretInteger: '3'
-  my_input_76:
-    SecretInteger: '3'
-  my_input_61:
-    SecretInteger: '3'
-  my_input_433:
-    SecretInteger: '3'
-  my_model_coef_0_149:
-    SecretInteger: '3'
-  my_model_coef_0_382:
-    SecretInteger: '3'
-  my_model_coef_0_418:
-    SecretInteger: '3'
-  my_input_222:
-    SecretInteger: '3'
-  my_model_coef_0_353:
-    SecretInteger: '3'
-  my_input_54:
-    SecretInteger: '3'
-  my_input_438:
-    SecretInteger: '3'
-  my_input_309:
-    SecretInteger: '3'
-  my_input_0:
-    SecretInteger: '3'
-  my_input_235:
-    SecretInteger: '3'
-  my_model_coef_0_50:
-    SecretInteger: '3'
-  my_model_coef_0_221:
-    SecretInteger: '3'
-  my_model_coef_0_106:
-    SecretInteger: '3'
-  my_input_340:
-    SecretInteger: '3'
-  my_model_coef_0_46:
-    SecretInteger: '3'
-  my_input_262:
-    SecretInteger: '3'
-  my_input_448:
-    SecretInteger: '3'
-  my_input_20:
-    SecretInteger: '3'
-  my_model_coef_0_343:
-    SecretInteger: '3'
-  my_model_coef_0_416:
-    SecretInteger: '3'
-  my_input_149:
-    SecretInteger: '3'
-  my_model_coef_0_169:
-    SecretInteger: '3'
-  my_model_coef_0_233:
-    SecretInteger: '3'
-  my_model_coef_0_123:
-    SecretInteger: '3'
-  my_input_304:
-    SecretInteger: '3'
-  my_input_36:
-    SecretInteger: '3'
-  my_input_65:
-    SecretInteger: '3'
-  my_input_359:
-    SecretInteger: '3'
-  my_input_337:
-    SecretInteger: '3'
-  my_model_coef_0_219:
-    SecretInteger: '3'
-  my_model_coef_0_92:
-    SecretInteger: '3'
-  my_input_154:
-    SecretInteger: '3'
-  my_model_coef_0_377:
-    SecretInteger: '3'
-  my_model_coef_0_255:
-    SecretInteger: '3'
-  my_input_497:
-    SecretInteger: '3'
-  my_model_coef_0_60:
-    SecretInteger: '3'
-  my_model_coef_0_344:
-    SecretInteger: '3'
-  my_model_coef_0_445:
-    SecretInteger: '3'
-  my_input_112:
-    SecretInteger: '3'
-  my_input_251:
-    SecretInteger: '3'
-  my_input_418:
-    SecretInteger: '3'
-  my_input_275:
-    SecretInteger: '3'
-  my_model_coef_0_214:
-    SecretInteger: '3'
-  my_input_224:
-    SecretInteger: '3'
-  my_input_459:
-    SecretInteger: '3'
-  my_model_coef_0_296:
-    SecretInteger: '3'
-  my_input_440:
-    SecretInteger: '3'
-  my_input_58:
-    SecretInteger: '3'
-  my_input_239:
-    SecretInteger: '3'
-  my_input_246:
-    SecretInteger: '3'
-  my_input_271:
-    SecretInteger: '3'
-  my_model_coef_0_482:
-    SecretInteger: '3'
-  my_model_coef_0_44:
-    SecretInteger: '3'
-  my_input_346:
-    SecretInteger: '3'
-  my_model_coef_0_109:
-    SecretInteger: '3'
-  my_model_coef_0_72:
-    SecretInteger: '3'
-  my_model_coef_0_328:
-    SecretInteger: '3'
-  my_model_coef_0_190:
-    SecretInteger: '3'
-  my_input_143:
-    SecretInteger: '3'
-  my_model_coef_0_30:
-    SecretInteger: '3'
-  my_model_coef_0_68:
-    SecretInteger: '3'
-  my_model_coef_0_406:
-    SecretInteger: '3'
-  my_model_coef_0_265:
-    SecretInteger: '3'
-  my_input_129:
-    SecretInteger: '3'
-  my_input_363:
-    SecretInteger: '3'
-  my_input_439:
-    SecretInteger: '3'
-  my_input_99:
-    SecretInteger: '3'
-  my_model_coef_0_222:
-    SecretInteger: '3'
-  my_model_coef_0_475:
-    SecretInteger: '3'
-  my_model_coef_0_65:
-    SecretInteger: '3'
-  my_model_coef_0_128:
-    SecretInteger: '3'
-  my_input_402:
-    SecretInteger: '3'
-  my_model_coef_0_315:
-    SecretInteger: '3'
-  my_input_403:
-    SecretInteger: '3'
-  my_input_481:
-    SecretInteger: '3'
-  my_model_coef_0_162:
-    SecretInteger: '3'
-  my_model_coef_0_266:
-    SecretInteger: '3'
-  my_model_coef_0_461:
-    SecretInteger: '3'
-  my_input_18:
-    SecretInteger: '3'
-  my_input_97:
-    SecretInteger: '3'
-  my_model_coef_0_459:
-    SecretInteger: '3'
-  my_input_130:
-    SecretInteger: '3'
-  my_input_295:
-    SecretInteger: '3'
-  my_model_coef_0_396:
-    SecretInteger: '3'
-  my_model_coef_0_239:
-    SecretInteger: '3'
-  my_model_coef_0_318:
-    SecretInteger: '3'
-  my_model_coef_0_324:
-    SecretInteger: '3'
-  my_model_coef_0_332:
-    SecretInteger: '3'
-  my_input_28:
-    SecretInteger: '3'
-  my_input_111:
-    SecretInteger: '3'
-  my_input_312:
-    SecretInteger: '3'
-  my_input_40:
-    SecretInteger: '3'
-  my_input_214:
-    SecretInteger: '3'
-  my_model_coef_0_51:
-    SecretInteger: '3'
-  my_model_coef_0_75:
-    SecretInteger: '3'
-  my_model_coef_0_345:
-    SecretInteger: '3'
-  my_model_coef_0_249:
-    SecretInteger: '3'
-  my_input_398:
-    SecretInteger: '3'
-  my_model_coef_0_269:
-    SecretInteger: '3'
-  my_model_coef_0_196:
-    SecretInteger: '3'
-  my_input_297:
-    SecretInteger: '3'
-  my_model_coef_0_450:
-    SecretInteger: '3'
-  my_model_coef_0_183:
-    SecretInteger: '3'
-  my_input_263:
-    SecretInteger: '3'
-  my_input_410:
-    SecretInteger: '3'
-  my_input_367:
-    SecretInteger: '3'
-  my_model_coef_0_496:
-    SecretInteger: '3'
-  my_input_107:
-    SecretInteger: '3'
-  my_model_coef_0_19:
-    SecretInteger: '3'
-  my_input_490:
-    SecretInteger: '3'
-  my_model_coef_0_218:
-    SecretInteger: '3'
-  my_model_coef_0_261:
-    SecretInteger: '3'
-  my_model_coef_0_370:
-    SecretInteger: '3'
-  my_input_479:
-    SecretInteger: '3'
-  my_input_401:
-    SecretInteger: '3'
-  my_input_423:
-    SecretInteger: '3'
-  my_input_95:
-    SecretInteger: '3'
-  my_model_coef_0_456:
-    SecretInteger: '3'
-  my_model_coef_0_189:
-    SecretInteger: '3'
-  my_model_coef_0_347:
-    SecretInteger: '3'
-  my_input_273:
-    SecretInteger: '3'
-  my_input_465:
-    SecretInteger: '3'
-  my_model_coef_0_356:
-    SecretInteger: '3'
-  my_input_311:
-    SecretInteger: '3'
-  my_model_coef_0_78:
-    SecretInteger: '3'
-  my_input_345:
-    SecretInteger: '3'
-  my_model_coef_0_63:
-    SecretInteger: '3'
-  my_input_396:
-    SecretInteger: '3'
-  my_model_coef_0_111:
-    SecretInteger: '3'
-  my_input_192:
-    SecretInteger: '3'
-  my_model_coef_0_1:
-    SecretInteger: '3'
-  my_input_33:
-    SecretInteger: '3'
-  my_model_coef_0_471:
-    SecretInteger: '3'
-  my_input_80:
-    SecretInteger: '3'
-  my_input_281:
-    SecretInteger: '3'
-  my_model_coef_0_3:
-    SecretInteger: '3'
-  my_model_coef_0_417:
-    SecretInteger: '3'
-  my_model_coef_0_462:
-    SecretInteger: '3'
-  my_model_coef_0_224:
-    SecretInteger: '3'
-  my_input_437:
-    SecretInteger: '3'
-  my_input_386:
-    SecretInteger: '3'
-  my_input_27:
-    SecretInteger: '3'
-  my_input_166:
-    SecretInteger: '3'
-  my_input_279:
-    SecretInteger: '3'
-  my_model_coef_0_197:
-    SecretInteger: '3'
-  my_model_coef_0_369:
-    SecretInteger: '3'
-  my_model_coef_0_133:
-    SecretInteger: '3'
-  my_input_141:
-    SecretInteger: '3'
-  my_model_coef_0_372:
-    SecretInteger: '3'
-  my_input_451:
-    SecretInteger: '3'
-  my_model_coef_0_415:
-    SecretInteger: '3'
-  my_model_coef_0_455:
-    SecretInteger: '3'
-  my_input_157:
-    SecretInteger: '3'
-  my_model_coef_0_487:
-    SecretInteger: '3'
-  my_input_210:
-    SecretInteger: '3'
-  my_model_coef_0_319:
-    SecretInteger: '3'
-  my_input_301:
-    SecretInteger: '3'
-  my_input_68:
-    SecretInteger: '3'
-  my_model_coef_0_431:
-    SecretInteger: '3'
-  my_input_234:
-    SecretInteger: '3'
-  my_model_coef_0_448:
-    SecretInteger: '3'
-  my_input_285:
-    SecretInteger: '3'
-  my_input_184:
-    SecretInteger: '3'
-  my_model_coef_0_228:
-    SecretInteger: '3'
-  my_input_360:
-    SecretInteger: '3'
-  my_input_436:
-    SecretInteger: '3'
-  my_input_331:
-    SecretInteger: '3'
-  my_model_coef_0_364:
-    SecretInteger: '3'
-  my_model_coef_0_317:
-    SecretInteger: '3'
-  my_model_coef_0_402:
-    SecretInteger: '3'
-  my_input_17:
-    SecretInteger: '3'
-  my_model_coef_0_61:
-    SecretInteger: '3'
-  my_input_351:
-    SecretInteger: '3'
-  my_input_370:
-    SecretInteger: '3'
-  my_input_429:
-    SecretInteger: '3'
-  my_input_393:
-    SecretInteger: '3'
-  my_input_211:
-    SecretInteger: '3'
-  my_model_coef_0_36:
-    SecretInteger: '3'
-  my_input_108:
-    SecretInteger: '3'
-  my_model_coef_0_278:
-    SecretInteger: '3'
-  my_model_coef_0_18:
-    SecretInteger: '3'
-  my_model_coef_0_84:
-    SecretInteger: '3'
-  my_model_coef_0_467:
-    SecretInteger: '3'
-  my_input_193:
-    SecretInteger: '3'
-  my_input_290:
-    SecretInteger: '3'
-  my_input_104:
-    SecretInteger: '3'
-  my_model_coef_0_490:
-    SecretInteger: '3'
-  my_input_78:
-    SecretInteger: '3'
-  my_input_457:
-    SecretInteger: '3'
-  my_input_238:
-    SecretInteger: '3'
-  my_input_259:
-    SecretInteger: '3'
-  my_model_coef_0_297:
-    SecretInteger: '3'
-  my_input_283:
-    SecretInteger: '3'
-  my_input_198:
-    SecretInteger: '3'
-  my_model_coef_0_195:
-    SecretInteger: '3'
-  my_model_coef_0_299:
-    SecretInteger: '3'
-  my_model_coef_0_257:
-    SecretInteger: '3'
-  my_model_coef_0_287:
-    SecretInteger: '3'
-  my_input_261:
-    SecretInteger: '3'
-  my_input_344:
-    SecretInteger: '3'
-  my_input_332:
-    SecretInteger: '3'
-  my_model_coef_0_419:
-    SecretInteger: '3'
-  my_model_coef_0_98:
-    SecretInteger: '3'
-  my_input_105:
-    SecretInteger: '3'
-  my_input_171:
-    SecretInteger: '3'
-  my_input_152:
-    SecretInteger: '3'
-  my_model_coef_0_237:
-    SecretInteger: '3'
-  my_model_coef_0_301:
-    SecretInteger: '3'
-  my_input_408:
-    SecretInteger: '3'
-  my_input_335:
-    SecretInteger: '3'
-  my_model_coef_0_207:
-    SecretInteger: '3'
-  my_model_coef_0_380:
-    SecretInteger: '3'
-  my_model_coef_0_393:
-    SecretInteger: '3'
-  my_input_317:
-    SecretInteger: '3'
-  my_input_163:
-    SecretInteger: '3'
-  my_input_415:
-    SecretInteger: '3'
-  my_input_467:
-    SecretInteger: '3'
-  my_input_21:
-    SecretInteger: '3'
-  my_input_88:
-    SecretInteger: '3'
-  my_model_coef_0_242:
-    SecretInteger: '3'
-  my_input_308:
-    SecretInteger: '3'
-  my_model_coef_0_7:
-    SecretInteger: '3'
-  my_model_coef_0_375:
-    SecretInteger: '3'
-  my_model_coef_0_285:
-    SecretInteger: '3'
-  my_input_215:
-    SecretInteger: '3'
-  my_input_12:
-    SecretInteger: '3'
-  my_input_343:
-    SecretInteger: '3'
-  my_model_coef_0_35:
-    SecretInteger: '3'
-  my_input_151:
-    SecretInteger: '3'
-  my_model_coef_0_271:
-    SecretInteger: '3'
-  my_input_397:
-    SecretInteger: '3'
-  my_input_389:
-    SecretInteger: '3'
-  my_input_425:
-    SecretInteger: '3'
-  my_input_388:
-    SecretInteger: '3'
-  my_model_coef_0_454:
-    SecretInteger: '3'
-  my_input_77:
-    SecretInteger: '3'
-  my_input_201:
-    SecretInteger: '3'
-  my_model_coef_0_407:
-    SecretInteger: '3'
-  my_input_51:
-    SecretInteger: '3'
-  my_input_334:
-    SecretInteger: '3'
-  my_model_coef_0_437:
-    SecretInteger: '3'
-  my_input_14:
-    SecretInteger: '3'
-  my_model_coef_0_206:
-    SecretInteger: '3'
-  my_model_coef_0_412:
-    SecretInteger: '3'
-  my_input_44:
-    SecretInteger: '3'
-  my_input_30:
-    SecretInteger: '3'
-  my_model_coef_0_71:
-    SecretInteger: '3'
-  my_model_coef_0_124:
-    SecretInteger: '3'
-  my_model_coef_0_286:
-    SecretInteger: '3'
-  my_input_2:
-    SecretInteger: '3'
-  my_model_coef_0_140:
-    SecretInteger: '3'
-  my_input_197:
-    SecretInteger: '3'
-  my_model_coef_0_66:
-    SecretInteger: '3'
-  my_model_coef_0_144:
-    SecretInteger: '3'
-  my_input_131:
-    SecretInteger: '3'
+  my_input_81: 3
+  my_input_417: 3
+  my_input_168: 3
+  my_input_75: 3
+  my_model_coef_0_81: 3
+  my_model_coef_0_194: 3
+  my_model_coef_0_210: 3
+  my_model_coef_0_108: 3
+  my_model_coef_0_476: 3
+  my_model_coef_0_182: 3
+  my_input_236: 3
+  my_input_13: 3
+  my_model_coef_0_229: 3
+  my_model_coef_0_147: 3
+  my_input_468: 3
+  my_model_coef_0_350: 3
+  my_input_252: 3
+  my_input_34: 3
+  my_model_coef_0_212: 3
+  my_input_330: 3
+  my_input_240: 3
+  my_input_133: 3
+  my_model_coef_0_166: 3
+  my_model_coef_0_174: 3
+  my_model_coef_0_425: 3
+  my_input_452: 3
+  my_model_coef_0_423: 3
+  my_model_coef_0_291: 3
+  my_model_coef_0_359: 3
+  my_model_coef_0_143: 3
+  my_model_coef_0_94: 3
+  my_model_coef_0_177: 3
+  my_input_217: 3
+  my_model_coef_0_80: 3
+  my_input_336: 3
+  my_input_472: 3
+  my_model_coef_0_232: 3
+  my_model_coef_0_274: 3
+  my_model_coef_0_256: 3
+  my_model_coef_0_368: 3
+  my_input_47: 3
+  my_input_79: 3
+  my_input_409: 3
+  my_model_coef_0_42: 3
+  my_model_coef_0_262: 3
+  my_model_coef_0_29: 3
+  my_input_48: 3
+  my_input_100: 3
+  my_model_coef_0_483: 3
+  my_input_372: 3
+  my_input_276: 3
+  my_input_221: 3
+  my_input_349: 3
+  my_model_coef_0_25: 3
+  my_input_422: 3
+  my_model_coef_0_379: 3
+  my_input_329: 3
+  my_input_482: 3
+  my_model_coef_0_234: 3
+  my_input_237: 3
+  my_input_435: 3
+  my_input_260: 3
+  my_model_coef_0_400: 3
+  my_model_coef_0_472: 3
+  my_model_coef_0_96: 3
+  my_model_coef_0_279: 3
+  my_input_230: 3
+  my_input_313: 3
+  my_input_444: 3
+  my_input_174: 3
+  my_model_coef_0_236: 3
+  my_input_122: 3
+  my_input_461: 3
+  my_input_1: 3
+  my_input_314: 3
+  my_input_325: 3
+  my_model_coef_0_243: 3
+  my_model_coef_0_383: 3
+  my_input_3: 3
+  my_input_195: 3
+  my_input_473: 3
+  my_input_464: 3
+  my_input_300: 3
+  my_model_coef_0_436: 3
+  my_input_243: 3
+  my_model_coef_0_192: 3
+  my_model_coef_0_421: 3
+  my_input_62: 3
+  my_input_255: 3
+  my_input_382: 3
+  my_input_247: 3
+  my_model_coef_0_116: 3
+  my_input_242: 3
+  my_model_coef_0_294: 3
+  my_model_coef_0_59: 3
+  my_model_coef_0_185: 3
+  my_model_coef_0_390: 3
+  my_model_coef_0_202: 3
+  my_model_coef_0_304: 3
+  my_model_coef_0_248: 3
+  my_input_69: 3
+  my_input_206: 3
+  my_input_485: 3
+  my_input_118: 3
+  my_input_307: 3
+  my_input_289: 3
+  my_input_45: 3
+  my_input_164: 3
+  my_input_181: 3
+  my_input_466: 3
+  my_input_84: 3
+  my_model_coef_0_208: 3
+  my_input_395: 3
+  my_input_127: 3
+  my_input_29: 3
+  my_input_144: 3
+  my_input_326: 3
+  my_input_495: 3
+  my_input_191: 3
+  my_model_coef_0_67: 3
+  my_model_coef_0_394: 3
+  my_input_319: 3
+  my_input_126: 3
+  my_input_431: 3
+  my_model_coef_0_388: 3
+  my_model_coef_0_227: 3
+  my_input_15: 3
+  my_input_128: 3
+  my_input_445: 3
+  my_input_59: 3
+  my_input_404: 3
+  my_input_158: 3
+  my_model_coef_0_470: 3
+  my_model_coef_0_137: 3
+  my_model_coef_0_33: 3
+  my_input_183: 3
+  my_model_coef_0_395: 3
+  my_input_323: 3
+  my_input_327: 3
+  my_input_113: 3
+  my_model_coef_0_498: 3
+  my_input_385: 3
+  my_input_362: 3
+  my_input_92: 3
+  my_model_coef_0_333: 3
+  my_input_49: 3
+  my_model_coef_0_241: 3
+  my_model_coef_0_361: 3
+  my_model_coef_0_381: 3
+  my_model_coef_0_409: 3
+  my_input_72: 3
+  my_input_123: 3
+  my_model_coef_0_64: 3
+  my_input_170: 3
+  my_input_328: 3
+  my_input_250: 3
+  my_input_341: 3
+  my_input_303: 3
+  my_input_426: 3
+  my_model_coef_0_131: 3
+  my_input_420: 3
+  my_model_coef_0_153: 3
+  my_model_coef_0_403: 3
+  my_input_67: 3
+  my_input_321: 3
+  my_model_coef_0_112: 3
+  my_input_486: 3
+  my_model_coef_0_6: 3
+  my_model_coef_0_357: 3
+  my_input_399: 3
+  my_input_432: 3
+  my_input_8: 3
+  my_model_coef_0_485: 3
+  my_input_407: 3
+  my_input_22: 3
+  my_model_coef_0_306: 3
+  my_model_coef_0_163: 3
+  my_input_196: 3
+  my_input_364: 3
+  my_model_coef_0_341: 3
+  my_input_350: 3
+  my_input_377: 3
+  my_input_454: 3
+  my_input_458: 3
+  my_model_coef_0_167: 3
+  my_model_coef_0_430: 3
+  my_model_coef_0_129: 3
+  my_input_400: 3
+  my_model_coef_0_41: 3
+  my_input_265: 3
+  my_model_coef_0_134: 3
+  my_model_coef_0_82: 3
+  my_model_coef_0_56: 3
+  my_input_38: 3
+  my_input_103: 3
+  my_model_coef_0_0: 3
+  my_model_coef_0_260: 3
+  my_model_coef_0_362: 3
+  my_input_443: 3
+  my_input_306: 3
+  my_model_coef_0_441: 3
+  my_model_coef_0_209: 3
+  my_model_coef_0_141: 3
+  my_model_coef_0_217: 3
+  my_model_coef_0_4: 3
+  my_model_coef_0_161: 3
+  my_model_coef_0_481: 3
+  my_input_119: 3
+  my_model_coef_0_204: 3
+  my_model_intercept_0: 3
+  my_input_177: 3
+  my_input_86: 3
+  my_model_coef_0_424: 3
+  my_model_coef_0_355: 3
+  my_model_coef_0_55: 3
+  my_input_231: 3
+  my_input_74: 3
+  my_model_coef_0_432: 3
+  my_input_455: 3
+  my_model_coef_0_17: 3
+  my_model_coef_0_119: 3
+  my_input_156: 3
+  my_input_190: 3
+  my_input_381: 3
+  my_input_421: 3
+  my_model_coef_0_447: 3
+  my_input_180: 3
+  my_input_489: 3
+  my_model_coef_0_363: 3
+  my_model_coef_0_440: 3
+  my_input_264: 3
+  my_model_coef_0_101: 3
+  my_model_coef_0_69: 3
+  my_model_coef_0_246: 3
+  my_model_coef_0_135: 3
+  my_input_499: 3
+  my_model_coef_0_346: 3
+  my_input_412: 3
+  my_input_441: 3
+  my_model_coef_0_272: 3
+  my_input_32: 3
+  my_model_coef_0_251: 3
+  my_input_16: 3
+  my_model_coef_0_254: 3
+  my_input_7: 3
+  my_input_384: 3
+  my_model_coef_0_392: 3
+  my_model_coef_0_62: 3
+  my_input_90: 3
+  my_input_194: 3
+  my_model_coef_0_468: 3
+  my_input_366: 3
+  my_input_405: 3
+  my_model_coef_0_13: 3
+  my_model_coef_0_159: 3
+  my_input_424: 3
+  my_input_254: 3
+  my_model_coef_0_428: 3
+  my_model_coef_0_21: 3
+  my_input_226: 3
+  my_model_coef_0_258: 3
+  my_input_310: 3
+  my_model_coef_0_426: 3
+  my_model_coef_0_477: 3
+  my_model_coef_0_24: 3
+  my_model_coef_0_85: 3
+  my_model_coef_0_37: 3
+  my_model_coef_0_145: 3
+  my_input_160: 3
+  my_input_256: 3
+  my_model_coef_0_91: 3
+  my_model_coef_0_399: 3
+  my_model_coef_0_309: 3
+  my_model_coef_0_9: 3
+  my_model_coef_0_367: 3
+  my_model_coef_0_326: 3
+  my_model_coef_0_329: 3
+  my_input_296: 3
+  my_input_484: 3
+  my_input_200: 3
+  my_model_coef_0_83: 3
+  my_input_462: 3
+  my_input_277: 3
+  my_model_coef_0_238: 3
+  my_model_coef_0_444: 3
+  my_model_coef_0_358: 3
+  my_model_coef_0_158: 3
+  my_input_390: 3
+  my_model_coef_0_307: 3
+  my_model_coef_0_493: 3
+  my_model_coef_0_323: 3
+  my_input_374: 3
+  my_input_469: 3
+  my_model_coef_0_488: 3
+  my_model_coef_0_213: 3
+  my_input_56: 3
+  my_model_coef_0_79: 3
+  my_input_159: 3
+  my_model_coef_0_429: 3
+  my_input_293: 3
+  my_input_167: 3
+  my_input_375: 3
+  my_model_coef_0_136: 3
+  my_input_43: 3
+  my_model_coef_0_157: 3
+  my_input_24: 3
+  my_input_5: 3
+  my_input_450: 3
+  my_input_42: 3
+  my_model_coef_0_76: 3
+  my_model_coef_0_464: 3
+  my_input_19: 3
+  my_model_coef_0_198: 3
+  my_input_249: 3
+  my_input_493: 3
+  my_model_coef_0_288: 3
+  my_input_302: 3
+  my_model_coef_0_150: 3
+  my_input_204: 3
+  my_input_60: 3
+  my_input_220: 3
+  my_model_coef_0_280: 3
+  my_model_coef_0_494: 3
+  my_model_coef_0_16: 3
+  my_input_322: 3
+  my_model_coef_0_268: 3
+  my_model_coef_0_489: 3
+  my_model_coef_0_442: 3
+  my_model_coef_0_374: 3
+  my_model_coef_0_478: 3
+  my_input_298: 3
+  my_input_483: 3
+  my_input_267: 3
+  my_model_coef_0_73: 3
+  my_input_368: 3
+  my_input_207: 3
+  my_model_coef_0_220: 3
+  my_input_318: 3
+  my_model_coef_0_492: 3
+  my_input_161: 3
+  my_model_coef_0_180: 3
+  my_model_coef_0_371: 3
+  my_model_coef_0_87: 3
+  my_model_coef_0_90: 3
+  my_model_coef_0_148: 3
+  my_model_coef_0_342: 3
+  my_model_coef_0_43: 3
+  my_input_73: 3
+  my_input_339: 3
+  my_model_coef_0_179: 3
+  my_input_338: 3
+  my_input_434: 3
+  my_input_475: 3
+  my_model_coef_0_107: 3
+  my_model_coef_0_211: 3
+  my_model_coef_0_473: 3
+  my_input_274: 3
+  my_input_447: 3
+  my_input_175: 3
+  my_input_55: 3
+  my_model_coef_0_171: 3
+  my_input_392: 3
+  my_model_coef_0_216: 3
+  my_input_145: 3
+  my_input_227: 3
+  my_model_coef_0_226: 3
+  my_model_coef_0_31: 3
+  my_input_98: 3
+  my_input_106: 3
+  my_input_216: 3
+  my_model_coef_0_126: 3
+  my_input_134: 3
+  my_model_coef_0_102: 3
+  my_input_324: 3
+  my_input_162: 3
+  my_input_121: 3
+  my_input_71: 3
+  my_input_491: 3
+  my_model_coef_0_58: 3
+  my_input_269: 3
+  my_input_383: 3
+  my_model_coef_0_303: 3
+  my_model_coef_0_120: 3
+  my_input_150: 3
+  my_model_coef_0_32: 3
+  my_model_coef_0_100: 3
+  my_input_52: 3
+  my_model_coef_0_397: 3
+  my_model_coef_0_181: 3
+  my_input_287: 3
+  my_model_coef_0_263: 3
+  my_model_coef_0_360: 3
+  my_input_110: 3
+  my_input_288: 3
+  my_input_305: 3
+  my_input_453: 3
+  my_input_232: 3
+  my_input_474: 3
+  my_model_coef_0_348: 3
+  my_model_coef_0_452: 3
+  my_model_coef_0_352: 3
+  my_input_4: 3
+  my_input_31: 3
+  my_model_coef_0_281: 3
+  my_input_365: 3
+  my_model_coef_0_103: 3
+  my_model_coef_0_175: 3
+  my_model_coef_0_138: 3
+  my_model_coef_0_40: 3
+  my_model_coef_0_230: 3
+  my_model_coef_0_193: 3
+  my_model_coef_0_200: 3
+  my_input_89: 3
+  my_model_coef_0_427: 3
+  my_input_480: 3
+  my_input_253: 3
+  my_model_coef_0_11: 3
+  my_model_coef_0_12: 3
+  my_model_coef_0_113: 3
+  my_model_coef_0_438: 3
+  my_model_coef_0_247: 3
+  my_input_284: 3
+  my_input_137: 3
+  my_model_coef_0_283: 3
+  my_model_coef_0_420: 3
+  my_input_176: 3
+  my_model_coef_0_223: 3
+  my_model_coef_0_435: 3
+  my_input_244: 3
+  my_input_477: 3
+  my_input_471: 3
+  my_input_114: 3
+  my_input_233: 3
+  my_model_coef_0_151: 3
+  my_model_coef_0_253: 3
+  my_model_coef_0_264: 3
+  my_model_coef_0_142: 3
+  my_model_coef_0_391: 3
+  my_model_coef_0_337: 3
+  my_input_369: 3
+  my_model_coef_0_284: 3
+  my_model_coef_0_314: 3
+  my_model_coef_0_28: 3
+  my_model_coef_0_334: 3
+  my_input_225: 3
+  my_input_358: 3
+  my_input_460: 3
+  my_model_coef_0_45: 3
+  my_model_coef_0_389: 3
+  my_input_406: 3
+  my_input_487: 3
+  my_model_coef_0_114: 3
+  my_model_coef_0_463: 3
+  my_model_coef_0_110: 3
+  my_input_299: 3
+  my_input_488: 3
+  my_input_352: 3
+  my_model_coef_0_313: 3
+  my_model_coef_0_376: 3
+  my_model_coef_0_164: 3
+  my_model_coef_0_414: 3
+  my_model_coef_0_22: 3
+  my_input_348: 3
+  my_input_315: 3
+  my_input_189: 3
+  my_input_347: 3
+  my_input_241: 3
+  my_input_41: 3
+  my_model_coef_0_235: 3
+  my_model_coef_0_244: 3
+  my_model_coef_0_378: 3
+  my_model_coef_0_401: 3
+  my_input_140: 3
+  my_input_463: 3
+  my_model_coef_0_340: 3
+  my_model_coef_0_205: 3
+  my_model_coef_0_127: 3
+  my_model_coef_0_191: 3
+  my_input_96: 3
+  my_input_146: 3
+  my_input_391: 3
+  my_model_coef_0_15: 3
+  my_model_coef_0_201: 3
+  my_input_355: 3
+  my_input_139: 3
+  my_input_270: 3
+  my_model_coef_0_20: 3
+  my_input_414: 3
+  my_model_coef_0_117: 3
+  my_input_428: 3
+  my_input_494: 3
+  my_model_coef_0_168: 3
+  my_input_266: 3
+  my_input_492: 3
+  my_input_94: 3
+  my_input_102: 3
+  my_model_coef_0_365: 3
+  my_input_212: 3
+  my_input_205: 3
+  my_input_213: 3
+  my_model_coef_0_39: 3
+  my_model_coef_0_404: 3
+  my_input_416: 3
+  my_input_258: 3
+  my_model_coef_0_245: 3
+  my_input_411: 3
+  my_input_278: 3
+  my_model_coef_0_311: 3
+  my_input_23: 3
+  my_input_282: 3
+  my_input_342: 3
+  my_model_coef_0_57: 3
+  my_model_coef_0_23: 3
+  my_input_496: 3
+  my_input_173: 3
+  my_input_82: 3
+  my_model_coef_0_88: 3
+  my_input_87: 3
+  my_model_coef_0_118: 3
+  my_input_138: 3
+  my_input_179: 3
+  my_input_120: 3
+  my_model_coef_0_316: 3
+  my_model_coef_0_240: 3
+  my_model_coef_0_351: 3
+  my_input_245: 3
+  my_model_coef_0_349: 3
+  my_model_coef_0_86: 3
+  my_input_178: 3
+  my_model_coef_0_336: 3
+  my_input_185: 3
+  my_input_187: 3
+  my_input_11: 3
+  my_model_coef_0_275: 3
+  my_model_coef_0_54: 3
+  my_model_coef_0_5: 3
+  my_model_coef_0_335: 3
+  my_input_413: 3
+  my_input_26: 3
+  my_model_coef_0_231: 3
+  my_model_coef_0_486: 3
+  my_input_125: 3
+  my_model_coef_0_225: 3
+  my_model_coef_0_295: 3
+  my_model_coef_0_282: 3
+  my_model_coef_0_289: 3
+  my_model_coef_0_95: 3
+  my_model_coef_0_411: 3
+  my_input_229: 3
+  my_input_165: 3
+  my_model_coef_0_27: 3
+  my_model_coef_0_250: 3
+  my_input_223: 3
+  my_input_6: 3
+  my_input_63: 3
+  my_model_coef_0_152: 3
+  my_input_188: 3
+  my_input_333: 3
+  my_model_coef_0_277: 3
+  my_model_coef_0_178: 3
+  my_input_109: 3
+  my_model_coef_0_330: 3
+  my_model_coef_0_386: 3
+  my_input_169: 3
+  my_model_coef_0_154: 3
+  my_model_coef_0_160: 3
+  my_model_coef_0_99: 3
+  my_input_294: 3
+  my_model_coef_0_451: 3
+  my_input_280: 3
+  my_model_coef_0_398: 3
+  my_input_394: 3
+  my_model_coef_0_497: 3
+  my_input_286: 3
+  my_input_387: 3
+  my_input_199: 3
+  my_model_coef_0_139: 3
+  my_model_coef_0_259: 3
+  my_model_coef_0_132: 3
+  my_model_coef_0_130: 3
+  my_model_coef_0_2: 3
+  my_model_coef_0_125: 3
+  my_model_coef_0_215: 3
+  my_model_coef_0_465: 3
+  my_model_coef_0_495: 3
+  my_model_coef_0_77: 3
+  my_model_coef_0_122: 3
+  my_model_coef_0_366: 3
+  my_model_coef_0_203: 3
+  my_model_coef_0_74: 3
+  my_model_coef_0_292: 3
+  my_input_53: 3
+  my_model_coef_0_300: 3
+  my_model_coef_0_298: 3
+  my_input_39: 3
+  my_input_46: 3
+  my_input_136: 3
+  my_input_9: 3
+  my_input_83: 3
+  my_input_478: 3
+  my_model_coef_0_53: 3
+  my_model_coef_0_199: 3
+  my_model_coef_0_458: 3
+  my_model_coef_0_387: 3
+  my_model_coef_0_310: 3
+  my_input_272: 3
+  my_model_coef_0_273: 3
+  my_model_coef_0_93: 3
+  my_model_coef_0_70: 3
+  my_input_50: 3
+  my_input_353: 3
+  my_input_442: 3
+  my_input_379: 3
+  my_model_coef_0_434: 3
+  my_input_93: 3
+  my_input_203: 3
+  my_input_64: 3
+  my_model_coef_0_499: 3
+  my_input_142: 3
+  my_input_182: 3
+  my_input_115: 3
+  my_input_117: 3
+  my_model_coef_0_104: 3
+  my_model_coef_0_156: 3
+  my_model_coef_0_293: 3
+  my_input_155: 3
+  my_input_148: 3
+  my_input_476: 3
+  my_model_coef_0_408: 3
+  my_model_coef_0_322: 3
+  my_model_coef_0_433: 3
+  my_model_coef_0_97: 3
+  my_input_116: 3
+  my_model_coef_0_186: 3
+  my_model_coef_0_439: 3
+  my_input_153: 3
+  my_model_coef_0_187: 3
+  my_input_248: 3
+  my_input_292: 3
+  my_input_25: 3
+  my_model_coef_0_105: 3
+  my_input_135: 3
+  my_input_427: 3
+  my_input_85: 3
+  my_model_coef_0_422: 3
+  my_model_coef_0_89: 3
+  my_input_147: 3
+  my_input_268: 3
+  my_model_coef_0_384: 3
+  my_model_coef_0_480: 3
+  my_model_coef_0_308: 3
+  my_model_coef_0_354: 3
+  my_input_132: 3
+  my_input_202: 3
+  my_input_357: 3
+  my_input_320: 3
+  my_input_209: 3
+  my_model_coef_0_172: 3
+  my_input_66: 3
+  my_input_124: 3
+  my_input_373: 3
+  my_model_coef_0_479: 3
+  my_model_coef_0_146: 3
+  my_model_coef_0_466: 3
+  my_model_coef_0_8: 3
+  my_input_356: 3
+  my_input_371: 3
+  my_input_378: 3
+  my_model_coef_0_121: 3
+  my_model_coef_0_170: 3
+  my_input_470: 3
+  my_model_coef_0_325: 3
+  my_model_coef_0_457: 3
+  my_input_101: 3
+  my_model_coef_0_52: 3
+  my_model_coef_0_270: 3
+  my_model_coef_0_26: 3
+  my_model_coef_0_290: 3
+  my_input_498: 3
+  my_model_coef_0_165: 3
+  my_input_449: 3
+  my_input_376: 3
+  my_model_coef_0_339: 3
+  my_input_316: 3
+  my_model_coef_0_188: 3
+  my_model_coef_0_413: 3
+  my_model_coef_0_338: 3
+  my_model_coef_0_10: 3
+  my_model_coef_0_469: 3
+  my_model_coef_0_276: 3
+  my_model_coef_0_155: 3
+  my_model_coef_0_115: 3
+  my_input_186: 3
+  my_input_446: 3
+  my_model_coef_0_173: 3
+  my_model_coef_0_405: 3
+  my_input_291: 3
+  my_model_coef_0_321: 3
+  my_model_coef_0_38: 3
+  my_model_coef_0_176: 3
+  my_model_coef_0_49: 3
+  my_model_coef_0_385: 3
+  my_model_coef_0_267: 3
+  my_model_coef_0_14: 3
+  my_model_coef_0_48: 3
+  my_model_coef_0_312: 3
+  my_input_430: 3
+  my_model_coef_0_373: 3
+  my_model_coef_0_443: 3
+  my_model_coef_0_327: 3
+  my_model_coef_0_453: 3
+  my_input_35: 3
+  my_input_208: 3
+  my_input_228: 3
+  my_model_coef_0_302: 3
+  my_model_coef_0_491: 3
+  my_model_coef_0_34: 3
+  my_model_coef_0_305: 3
+  my_model_coef_0_320: 3
+  my_input_380: 3
+  my_model_coef_0_47: 3
+  my_input_419: 3
+  my_model_coef_0_484: 3
+  my_input_70: 3
+  my_input_218: 3
+  my_model_coef_0_474: 3
+  my_input_257: 3
+  my_input_361: 3
+  my_input_219: 3
+  my_model_coef_0_331: 3
+  my_input_37: 3
+  my_input_456: 3
+  my_model_coef_0_252: 3
+  my_input_57: 3
+  my_input_91: 3
+  my_model_coef_0_446: 3
+  my_model_coef_0_184: 3
+  my_input_354: 3
+  my_model_coef_0_410: 3
+  my_input_10: 3
+  my_input_172: 3
+  my_model_coef_0_460: 3
+  my_model_coef_0_449: 3
+  my_input_76: 3
+  my_input_61: 3
+  my_input_433: 3
+  my_model_coef_0_149: 3
+  my_model_coef_0_382: 3
+  my_model_coef_0_418: 3
+  my_input_222: 3
+  my_model_coef_0_353: 3
+  my_input_54: 3
+  my_input_438: 3
+  my_input_309: 3
+  my_input_0: 3
+  my_input_235: 3
+  my_model_coef_0_50: 3
+  my_model_coef_0_221: 3
+  my_model_coef_0_106: 3
+  my_input_340: 3
+  my_model_coef_0_46: 3
+  my_input_262: 3
+  my_input_448: 3
+  my_input_20: 3
+  my_model_coef_0_343: 3
+  my_model_coef_0_416: 3
+  my_input_149: 3
+  my_model_coef_0_169: 3
+  my_model_coef_0_233: 3
+  my_model_coef_0_123: 3
+  my_input_304: 3
+  my_input_36: 3
+  my_input_65: 3
+  my_input_359: 3
+  my_input_337: 3
+  my_model_coef_0_219: 3
+  my_model_coef_0_92: 3
+  my_input_154: 3
+  my_model_coef_0_377: 3
+  my_model_coef_0_255: 3
+  my_input_497: 3
+  my_model_coef_0_60: 3
+  my_model_coef_0_344: 3
+  my_model_coef_0_445: 3
+  my_input_112: 3
+  my_input_251: 3
+  my_input_418: 3
+  my_input_275: 3
+  my_model_coef_0_214: 3
+  my_input_224: 3
+  my_input_459: 3
+  my_model_coef_0_296: 3
+  my_input_440: 3
+  my_input_58: 3
+  my_input_239: 3
+  my_input_246: 3
+  my_input_271: 3
+  my_model_coef_0_482: 3
+  my_model_coef_0_44: 3
+  my_input_346: 3
+  my_model_coef_0_109: 3
+  my_model_coef_0_72: 3
+  my_model_coef_0_328: 3
+  my_model_coef_0_190: 3
+  my_input_143: 3
+  my_model_coef_0_30: 3
+  my_model_coef_0_68: 3
+  my_model_coef_0_406: 3
+  my_model_coef_0_265: 3
+  my_input_129: 3
+  my_input_363: 3
+  my_input_439: 3
+  my_input_99: 3
+  my_model_coef_0_222: 3
+  my_model_coef_0_475: 3
+  my_model_coef_0_65: 3
+  my_model_coef_0_128: 3
+  my_input_402: 3
+  my_model_coef_0_315: 3
+  my_input_403: 3
+  my_input_481: 3
+  my_model_coef_0_162: 3
+  my_model_coef_0_266: 3
+  my_model_coef_0_461: 3
+  my_input_18: 3
+  my_input_97: 3
+  my_model_coef_0_459: 3
+  my_input_130: 3
+  my_input_295: 3
+  my_model_coef_0_396: 3
+  my_model_coef_0_239: 3
+  my_model_coef_0_318: 3
+  my_model_coef_0_324: 3
+  my_model_coef_0_332: 3
+  my_input_28: 3
+  my_input_111: 3
+  my_input_312: 3
+  my_input_40: 3
+  my_input_214: 3
+  my_model_coef_0_51: 3
+  my_model_coef_0_75: 3
+  my_model_coef_0_345: 3
+  my_model_coef_0_249: 3
+  my_input_398: 3
+  my_model_coef_0_269: 3
+  my_model_coef_0_196: 3
+  my_input_297: 3
+  my_model_coef_0_450: 3
+  my_model_coef_0_183: 3
+  my_input_263: 3
+  my_input_410: 3
+  my_input_367: 3
+  my_model_coef_0_496: 3
+  my_input_107: 3
+  my_model_coef_0_19: 3
+  my_input_490: 3
+  my_model_coef_0_218: 3
+  my_model_coef_0_261: 3
+  my_model_coef_0_370: 3
+  my_input_479: 3
+  my_input_401: 3
+  my_input_423: 3
+  my_input_95: 3
+  my_model_coef_0_456: 3
+  my_model_coef_0_189: 3
+  my_model_coef_0_347: 3
+  my_input_273: 3
+  my_input_465: 3
+  my_model_coef_0_356: 3
+  my_input_311: 3
+  my_model_coef_0_78: 3
+  my_input_345: 3
+  my_model_coef_0_63: 3
+  my_input_396: 3
+  my_model_coef_0_111: 3
+  my_input_192: 3
+  my_model_coef_0_1: 3
+  my_input_33: 3
+  my_model_coef_0_471: 3
+  my_input_80: 3
+  my_input_281: 3
+  my_model_coef_0_3: 3
+  my_model_coef_0_417: 3
+  my_model_coef_0_462: 3
+  my_model_coef_0_224: 3
+  my_input_437: 3
+  my_input_386: 3
+  my_input_27: 3
+  my_input_166: 3
+  my_input_279: 3
+  my_model_coef_0_197: 3
+  my_model_coef_0_369: 3
+  my_model_coef_0_133: 3
+  my_input_141: 3
+  my_model_coef_0_372: 3
+  my_input_451: 3
+  my_model_coef_0_415: 3
+  my_model_coef_0_455: 3
+  my_input_157: 3
+  my_model_coef_0_487: 3
+  my_input_210: 3
+  my_model_coef_0_319: 3
+  my_input_301: 3
+  my_input_68: 3
+  my_model_coef_0_431: 3
+  my_input_234: 3
+  my_model_coef_0_448: 3
+  my_input_285: 3
+  my_input_184: 3
+  my_model_coef_0_228: 3
+  my_input_360: 3
+  my_input_436: 3
+  my_input_331: 3
+  my_model_coef_0_364: 3
+  my_model_coef_0_317: 3
+  my_model_coef_0_402: 3
+  my_input_17: 3
+  my_model_coef_0_61: 3
+  my_input_351: 3
+  my_input_370: 3
+  my_input_429: 3
+  my_input_393: 3
+  my_input_211: 3
+  my_model_coef_0_36: 3
+  my_input_108: 3
+  my_model_coef_0_278: 3
+  my_model_coef_0_18: 3
+  my_model_coef_0_84: 3
+  my_model_coef_0_467: 3
+  my_input_193: 3
+  my_input_290: 3
+  my_input_104: 3
+  my_model_coef_0_490: 3
+  my_input_78: 3
+  my_input_457: 3
+  my_input_238: 3
+  my_input_259: 3
+  my_model_coef_0_297: 3
+  my_input_283: 3
+  my_input_198: 3
+  my_model_coef_0_195: 3
+  my_model_coef_0_299: 3
+  my_model_coef_0_257: 3
+  my_model_coef_0_287: 3
+  my_input_261: 3
+  my_input_344: 3
+  my_input_332: 3
+  my_model_coef_0_419: 3
+  my_model_coef_0_98: 3
+  my_input_105: 3
+  my_input_171: 3
+  my_input_152: 3
+  my_model_coef_0_237: 3
+  my_model_coef_0_301: 3
+  my_input_408: 3
+  my_input_335: 3
+  my_model_coef_0_207: 3
+  my_model_coef_0_380: 3
+  my_model_coef_0_393: 3
+  my_input_317: 3
+  my_input_163: 3
+  my_input_415: 3
+  my_input_467: 3
+  my_input_21: 3
+  my_input_88: 3
+  my_model_coef_0_242: 3
+  my_input_308: 3
+  my_model_coef_0_7: 3
+  my_model_coef_0_375: 3
+  my_model_coef_0_285: 3
+  my_input_215: 3
+  my_input_12: 3
+  my_input_343: 3
+  my_model_coef_0_35: 3
+  my_input_151: 3
+  my_model_coef_0_271: 3
+  my_input_397: 3
+  my_input_389: 3
+  my_input_425: 3
+  my_input_388: 3
+  my_model_coef_0_454: 3
+  my_input_77: 3
+  my_input_201: 3
+  my_model_coef_0_407: 3
+  my_input_51: 3
+  my_input_334: 3
+  my_model_coef_0_437: 3
+  my_input_14: 3
+  my_model_coef_0_206: 3
+  my_model_coef_0_412: 3
+  my_input_44: 3
+  my_input_30: 3
+  my_model_coef_0_71: 3
+  my_model_coef_0_124: 3
+  my_model_coef_0_286: 3
+  my_input_2: 3
+  my_model_coef_0_140: 3
+  my_input_197: 3
+  my_model_coef_0_66: 3
+  my_model_coef_0_144: 3
+  my_input_131: 3
 expected_outputs:
-  logit_0:
-    SecretInteger: '3'
+  logit_0: 3

--- a/examples/time_series/main.py
+++ b/examples/time_series/main.py
@@ -12,17 +12,18 @@ import nada_numpy.client as na_client
 import numpy as np
 import pandas as pd
 import py_nillion_client as nillion
+from common.utils import compute, store_program, store_secrets
 from config import DIM, FORECAST_HORIZON
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.keypairs import PrivateKey
 from dotenv import load_dotenv
-from nada_ai.client import ProphetClient
-from nillion_python_helpers import create_nillion_client, create_payments_config
+from nillion_python_helpers import (create_nillion_client,
+                                    create_payments_config)
 from prophet import Prophet
 from py_nillion_client import NodeKey, UserKey
 
-from common.utils import compute, store_program, store_secrets
+from nada_ai.client import ProphetClient
 
 home = os.getenv("HOME")
 load_dotenv(f"{home}/.config/nillion/nillion-devnet.env")

--- a/examples/time_series/src/time_series.py
+++ b/examples/time_series/src/time_series.py
@@ -3,8 +3,9 @@ from typing import List
 import nada_numpy as na
 import numpy as np
 from config import TIME_HORIZON
-from nada_ai.time_series import Prophet
 from nada_dsl import Output
+
+from nada_ai.time_series import Prophet
 
 
 def nada_main() -> List[Output]:

--- a/examples/time_series/tests/time_series.yaml
+++ b/examples/time_series/tests/time_series.yaml
@@ -1,189 +1,96 @@
 program: time_series
 inputs:
-  my_prophet_changepoints_t_8:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_11:
-    SecretInteger: '3'
-  floor_17:
-    SecretInteger: '3'
-  floor_4:
-    SecretInteger: '3'
-  my_prophet_beta_0_3:
-    SecretInteger: '3'
-  t_7:
-    SecretInteger: '3'
-  t_3:
-    SecretInteger: '3'
-  my_prophet_beta_0_0:
-    SecretInteger: '3'
-  t_1:
-    SecretInteger: '3'
-  floor_5:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_6:
-    SecretInteger: '3'
-  floor_16:
-    SecretInteger: '3'
-  my_prophet_y_scale_0:
-    SecretInteger: '3'
-  floor_2:
-    SecretInteger: '3'
-  floor_19:
-    SecretInteger: '3'
-  my_prophet_beta_0_5:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_7:
-    SecretInteger: '3'
-  my_prophet_delta_0_5:
-    SecretInteger: '3'
-  t_8:
-    SecretInteger: '3'
-  floor_18:
-    SecretInteger: '3'
-  my_prophet_beta_0_2:
-    SecretInteger: '3'
-  floor_10:
-    SecretInteger: '3'
-  t_12:
-    SecretInteger: '3'
-  my_prophet_delta_0_4:
-    SecretInteger: '3'
-  t_14:
-    SecretInteger: '3'
-  t_16:
-    SecretInteger: '3'
-  t_2:
-    SecretInteger: '3'
-  t_5:
-    SecretInteger: '3'
-  floor_11:
-    SecretInteger: '3'
-  my_prophet_delta_0_2:
-    SecretInteger: '3'
-  my_prophet_delta_0_7:
-    SecretInteger: '3'
-  my_prophet_k_0_0:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_1:
-    SecretInteger: '3'
-  t_13:
-    SecretInteger: '3'
-  t_18:
-    SecretInteger: '3'
-  my_prophet_delta_0_0:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_9:
-    SecretInteger: '3'
-  floor_13:
-    SecretInteger: '3'
-  t_15:
-    SecretInteger: '3'
-  t_17:
-    SecretInteger: '3'
-  my_prophet_delta_0_6:
-    SecretInteger: '3'
-  t_10:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_10:
-    SecretInteger: '3'
-  my_prophet_beta_0_4:
-    SecretInteger: '3'
-  floor_3:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_2:
-    SecretInteger: '3'
-  t_9:
-    SecretInteger: '3'
-  floor_9:
-    SecretInteger: '3'
-  t_11:
-    SecretInteger: '3'
-  my_prophet_delta_0_3:
-    SecretInteger: '3'
-  my_prophet_delta_0_10:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_3:
-    SecretInteger: '3'
-  floor_1:
-    SecretInteger: '3'
-  my_prophet_delta_0_8:
-    SecretInteger: '3'
-  t_19:
-    SecretInteger: '3'
-  floor_7:
-    SecretInteger: '3'
-  floor_0:
-    SecretInteger: '3'
-  floor_14:
-    SecretInteger: '3'
-  floor_8:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_4:
-    SecretInteger: '3'
-  floor_12:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_0:
-    SecretInteger: '3'
-  my_prophet_delta_0_9:
-    SecretInteger: '3'
-  my_prophet_m_0_0:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_5:
-    SecretInteger: '3'
-  t_6:
-    SecretInteger: '3'
-  my_prophet_beta_0_1:
-    SecretInteger: '3'
-  t_0:
-    SecretInteger: '3'
-  floor_15:
-    SecretInteger: '3'
-  t_4:
-    SecretInteger: '3'
-  my_prophet_delta_0_11:
-    SecretInteger: '3'
-  my_prophet_delta_0_1:
-    SecretInteger: '3'
-  floor_6:
-    SecretInteger: '3'
+  my_prophet_changepoints_t_8: 3
+  my_prophet_changepoints_t_11: 3
+  floor_17: 3
+  floor_4: 3
+  my_prophet_beta_0_3: 3
+  t_7: 3
+  t_3: 3
+  my_prophet_beta_0_0: 3
+  t_1: 3
+  floor_5: 3
+  my_prophet_changepoints_t_6: 3
+  floor_16: 3
+  my_prophet_y_scale_0: 3
+  floor_2: 3
+  floor_19: 3
+  my_prophet_beta_0_5: 3
+  my_prophet_changepoints_t_7: 3
+  my_prophet_delta_0_5: 3
+  t_8: 3
+  floor_18: 3
+  my_prophet_beta_0_2: 3
+  floor_10: 3
+  t_12: 3
+  my_prophet_delta_0_4: 3
+  t_14: 3
+  t_16: 3
+  t_2: 3
+  t_5: 3
+  floor_11: 3
+  my_prophet_delta_0_2: 3
+  my_prophet_delta_0_7: 3
+  my_prophet_k_0_0: 3
+  my_prophet_changepoints_t_1: 3
+  t_13: 3
+  t_18: 3
+  my_prophet_delta_0_0: 3
+  my_prophet_changepoints_t_9: 3
+  floor_13: 3
+  t_15: 3
+  t_17: 3
+  my_prophet_delta_0_6: 3
+  t_10: 3
+  my_prophet_changepoints_t_10: 3
+  my_prophet_beta_0_4: 3
+  floor_3: 3
+  my_prophet_changepoints_t_2: 3
+  t_9: 3
+  floor_9: 3
+  t_11: 3
+  my_prophet_delta_0_3: 3
+  my_prophet_delta_0_10: 3
+  my_prophet_changepoints_t_3: 3
+  floor_1: 3
+  my_prophet_delta_0_8: 3
+  t_19: 3
+  floor_7: 3
+  floor_0: 3
+  floor_14: 3
+  floor_8: 3
+  my_prophet_changepoints_t_4: 3
+  floor_12: 3
+  my_prophet_changepoints_t_0: 3
+  my_prophet_delta_0_9: 3
+  my_prophet_m_0_0: 3
+  my_prophet_changepoints_t_5: 3
+  t_6: 3
+  my_prophet_beta_0_1: 3
+  t_0: 3
+  floor_15: 3
+  t_4: 3
+  my_prophet_delta_0_11: 3
+  my_prophet_delta_0_1: 3
+  floor_6: 3
 expected_outputs:
-  my_output_1:
-    SecretInteger: '2'
-  my_output_16:
-    SecretInteger: '2'
-  my_output_17:
-    SecretInteger: '1'
-  my_output_14:
-    SecretInteger: '1'
-  my_output_19:
-    SecretInteger: '1'
-  my_output_3:
-    SecretInteger: '1'
-  my_output_2:
-    SecretInteger: '2'
-  my_output_0:
-    SecretInteger: '1'
-  my_output_11:
-    SecretInteger: '2'
-  my_output_10:
-    SecretInteger: '1'
-  my_output_5:
-    SecretInteger: '1'
-  my_output_6:
-    SecretInteger: '1'
-  my_output_7:
-    SecretInteger: '1'
-  my_output_12:
-    SecretInteger: '1'
-  my_output_9:
-    SecretInteger: '2'
-  my_output_4:
-    SecretInteger: '2'
-  my_output_8:
-    SecretInteger: '2'
-  my_output_15:
-    SecretInteger: '2'
-  my_output_18:
-    SecretInteger: '2'
-  my_output_13:
-    SecretInteger: '1'
+  my_output_1: 2
+  my_output_16: 2
+  my_output_17: 1
+  my_output_14: 1
+  my_output_19: 1
+  my_output_3: 1
+  my_output_2: 2
+  my_output_0: 1
+  my_output_11: 2
+  my_output_10: 1
+  my_output_5: 1
+  my_output_6: 1
+  my_output_7: 1
+  my_output_12: 1
+  my_output_9: 2
+  my_output_4: 2
+  my_output_8: 2
+  my_output_15: 2
+  my_output_18: 2
+  my_output_13: 1

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,22 +34,22 @@ test = ["astroid (>=1,<2)", "astroid (>=2,<4)", "pytest"]
 
 [[package]]
 name = "attrs"
-version = "23.2.0"
+version = "24.2.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
-    {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
+    {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
+    {file = "attrs-24.2.0.tar.gz", hash = "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346"},
 ]
 
 [package.extras]
-cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
-dev = ["attrs[tests]", "pre-commit"]
-docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
-tests = ["attrs[tests-no-zope]", "zope-interface"]
-tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
-tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
+benchmark = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+cov = ["cloudpickle", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "bech32"
@@ -64,33 +64,33 @@ files = [
 
 [[package]]
 name = "black"
-version = "24.4.2"
+version = "24.8.0"
 description = "The uncompromising code formatter."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "black-24.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dd1b5a14e417189db4c7b64a6540f31730713d173f0b63e55fabd52d61d8fdce"},
-    {file = "black-24.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e537d281831ad0e71007dcdcbe50a71470b978c453fa41ce77186bbe0ed6021"},
-    {file = "black-24.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaea3008c281f1038edb473c1aa8ed8143a5535ff18f978a318f10302b254063"},
-    {file = "black-24.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:7768a0dbf16a39aa5e9a3ded568bb545c8c2727396d063bbaf847df05b08cd96"},
-    {file = "black-24.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474"},
-    {file = "black-24.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c"},
-    {file = "black-24.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb"},
-    {file = "black-24.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1"},
-    {file = "black-24.4.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:accf49e151c8ed2c0cdc528691838afd217c50412534e876a19270fea1e28e2d"},
-    {file = "black-24.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:88c57dc656038f1ab9f92b3eb5335ee9b021412feaa46330d5eba4e51fe49b04"},
-    {file = "black-24.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be8bef99eb46d5021bf053114442914baeb3649a89dc5f3a555c88737e5e98fc"},
-    {file = "black-24.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:415e686e87dbbe6f4cd5ef0fbf764af7b89f9057b97c908742b6008cc554b9c0"},
-    {file = "black-24.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bf10f7310db693bb62692609b397e8d67257c55f949abde4c67f9cc574492cc7"},
-    {file = "black-24.4.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:98e123f1d5cfd42f886624d84464f7756f60ff6eab89ae845210631714f6db94"},
-    {file = "black-24.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48a85f2cb5e6799a9ef05347b476cce6c182d6c71ee36925a6c194d074336ef8"},
-    {file = "black-24.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:b1530ae42e9d6d5b670a34db49a94115a64596bc77710b1d05e9801e62ca0a7c"},
-    {file = "black-24.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:37aae07b029fa0174d39daf02748b379399b909652a806e5708199bd93899da1"},
-    {file = "black-24.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:da33a1a5e49c4122ccdfd56cd021ff1ebc4a1ec4e2d01594fef9b6f267a9e741"},
-    {file = "black-24.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef703f83fc32e131e9bcc0a5094cfe85599e7109f896fe8bc96cc402f3eb4b6e"},
-    {file = "black-24.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:b9176b9832e84308818a99a561e90aa479e73c523b3f77afd07913380ae2eab7"},
-    {file = "black-24.4.2-py3-none-any.whl", hash = "sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c"},
-    {file = "black-24.4.2.tar.gz", hash = "sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d"},
+    {file = "black-24.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6"},
+    {file = "black-24.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb"},
+    {file = "black-24.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42"},
+    {file = "black-24.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a"},
+    {file = "black-24.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1"},
+    {file = "black-24.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af"},
+    {file = "black-24.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4"},
+    {file = "black-24.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af"},
+    {file = "black-24.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368"},
+    {file = "black-24.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed"},
+    {file = "black-24.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018"},
+    {file = "black-24.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2"},
+    {file = "black-24.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd"},
+    {file = "black-24.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2"},
+    {file = "black-24.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e"},
+    {file = "black-24.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920"},
+    {file = "black-24.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c"},
+    {file = "black-24.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e"},
+    {file = "black-24.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47"},
+    {file = "black-24.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb"},
+    {file = "black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed"},
+    {file = "black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f"},
 ]
 
 [package.dependencies]
@@ -110,13 +110,13 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "certifi"
-version = "2024.7.4"
+version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
-    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
+    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
+    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
 ]
 
 [[package]]
@@ -267,66 +267,87 @@ files = [
 
 [[package]]
 name = "contourpy"
-version = "1.2.1"
+version = "1.3.0"
 description = "Python library for calculating contours of 2D quadrilateral grids"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "contourpy-1.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bd7c23df857d488f418439686d3b10ae2fbf9bc256cd045b37a8c16575ea1040"},
-    {file = "contourpy-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5b9eb0ca724a241683c9685a484da9d35c872fd42756574a7cfbf58af26677fd"},
-    {file = "contourpy-1.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c75507d0a55378240f781599c30e7776674dbaf883a46d1c90f37e563453480"},
-    {file = "contourpy-1.2.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:11959f0ce4a6f7b76ec578576a0b61a28bdc0696194b6347ba3f1c53827178b9"},
-    {file = "contourpy-1.2.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb3315a8a236ee19b6df481fc5f997436e8ade24a9f03dfdc6bd490fea20c6da"},
-    {file = "contourpy-1.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39f3ecaf76cd98e802f094e0d4fbc6dc9c45a8d0c4d185f0f6c2234e14e5f75b"},
-    {file = "contourpy-1.2.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:94b34f32646ca0414237168d68a9157cb3889f06b096612afdd296003fdd32fd"},
-    {file = "contourpy-1.2.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:457499c79fa84593f22454bbd27670227874cd2ff5d6c84e60575c8b50a69619"},
-    {file = "contourpy-1.2.1-cp310-cp310-win32.whl", hash = "sha256:ac58bdee53cbeba2ecad824fa8159493f0bf3b8ea4e93feb06c9a465d6c87da8"},
-    {file = "contourpy-1.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:9cffe0f850e89d7c0012a1fb8730f75edd4320a0a731ed0c183904fe6ecfc3a9"},
-    {file = "contourpy-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6022cecf8f44e36af10bd9118ca71f371078b4c168b6e0fab43d4a889985dbb5"},
-    {file = "contourpy-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef5adb9a3b1d0c645ff694f9bca7702ec2c70f4d734f9922ea34de02294fdf72"},
-    {file = "contourpy-1.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6150ffa5c767bc6332df27157d95442c379b7dce3a38dff89c0f39b63275696f"},
-    {file = "contourpy-1.2.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c863140fafc615c14a4bf4efd0f4425c02230eb8ef02784c9a156461e62c965"},
-    {file = "contourpy-1.2.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:00e5388f71c1a0610e6fe56b5c44ab7ba14165cdd6d695429c5cd94021e390b2"},
-    {file = "contourpy-1.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4492d82b3bc7fbb7e3610747b159869468079fe149ec5c4d771fa1f614a14df"},
-    {file = "contourpy-1.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:49e70d111fee47284d9dd867c9bb9a7058a3c617274900780c43e38d90fe1205"},
-    {file = "contourpy-1.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:b59c0ffceff8d4d3996a45f2bb6f4c207f94684a96bf3d9728dbb77428dd8cb8"},
-    {file = "contourpy-1.2.1-cp311-cp311-win32.whl", hash = "sha256:7b4182299f251060996af5249c286bae9361fa8c6a9cda5efc29fe8bfd6062ec"},
-    {file = "contourpy-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2855c8b0b55958265e8b5888d6a615ba02883b225f2227461aa9127c578a4922"},
-    {file = "contourpy-1.2.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:62828cada4a2b850dbef89c81f5a33741898b305db244904de418cc957ff05dc"},
-    {file = "contourpy-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:309be79c0a354afff9ff7da4aaed7c3257e77edf6c1b448a779329431ee79d7e"},
-    {file = "contourpy-1.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e785e0f2ef0d567099b9ff92cbfb958d71c2d5b9259981cd9bee81bd194c9a4"},
-    {file = "contourpy-1.2.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1cac0a8f71a041aa587410424ad46dfa6a11f6149ceb219ce7dd48f6b02b87a7"},
-    {file = "contourpy-1.2.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:af3f4485884750dddd9c25cb7e3915d83c2db92488b38ccb77dd594eac84c4a0"},
-    {file = "contourpy-1.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ce6889abac9a42afd07a562c2d6d4b2b7134f83f18571d859b25624a331c90b"},
-    {file = "contourpy-1.2.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:a1eea9aecf761c661d096d39ed9026574de8adb2ae1c5bd7b33558af884fb2ce"},
-    {file = "contourpy-1.2.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:187fa1d4c6acc06adb0fae5544c59898ad781409e61a926ac7e84b8f276dcef4"},
-    {file = "contourpy-1.2.1-cp312-cp312-win32.whl", hash = "sha256:c2528d60e398c7c4c799d56f907664673a807635b857df18f7ae64d3e6ce2d9f"},
-    {file = "contourpy-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:1a07fc092a4088ee952ddae19a2b2a85757b923217b7eed584fdf25f53a6e7ce"},
-    {file = "contourpy-1.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bb6834cbd983b19f06908b45bfc2dad6ac9479ae04abe923a275b5f48f1a186b"},
-    {file = "contourpy-1.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1d59e739ab0e3520e62a26c60707cc3ab0365d2f8fecea74bfe4de72dc56388f"},
-    {file = "contourpy-1.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd3db01f59fdcbce5b22afad19e390260d6d0222f35a1023d9adc5690a889364"},
-    {file = "contourpy-1.2.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a12a813949e5066148712a0626895c26b2578874e4cc63160bb007e6df3436fe"},
-    {file = "contourpy-1.2.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fe0ccca550bb8e5abc22f530ec0466136379c01321fd94f30a22231e8a48d985"},
-    {file = "contourpy-1.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1d59258c3c67c865435d8fbeb35f8c59b8bef3d6f46c1f29f6123556af28445"},
-    {file = "contourpy-1.2.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f32c38afb74bd98ce26de7cc74a67b40afb7b05aae7b42924ea990d51e4dac02"},
-    {file = "contourpy-1.2.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d31a63bc6e6d87f77d71e1abbd7387ab817a66733734883d1fc0021ed9bfa083"},
-    {file = "contourpy-1.2.1-cp39-cp39-win32.whl", hash = "sha256:ddcb8581510311e13421b1f544403c16e901c4e8f09083c881fab2be80ee31ba"},
-    {file = "contourpy-1.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:10a37ae557aabf2509c79715cd20b62e4c7c28b8cd62dd7d99e5ed3ce28c3fd9"},
-    {file = "contourpy-1.2.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a31f94983fecbac95e58388210427d68cd30fe8a36927980fab9c20062645609"},
-    {file = "contourpy-1.2.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef2b055471c0eb466033760a521efb9d8a32b99ab907fc8358481a1dd29e3bd3"},
-    {file = "contourpy-1.2.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:b33d2bc4f69caedcd0a275329eb2198f560b325605810895627be5d4b876bf7f"},
-    {file = "contourpy-1.2.1.tar.gz", hash = "sha256:4d8908b3bee1c889e547867ca4cdc54e5ab6be6d3e078556814a22457f49423c"},
+    {file = "contourpy-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:880ea32e5c774634f9fcd46504bf9f080a41ad855f4fef54f5380f5133d343c7"},
+    {file = "contourpy-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:76c905ef940a4474a6289c71d53122a4f77766eef23c03cd57016ce19d0f7b42"},
+    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92f8557cbb07415a4d6fa191f20fd9d2d9eb9c0b61d1b2f52a8926e43c6e9af7"},
+    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:36f965570cff02b874773c49bfe85562b47030805d7d8360748f3eca570f4cab"},
+    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cacd81e2d4b6f89c9f8a5b69b86490152ff39afc58a95af002a398273e5ce589"},
+    {file = "contourpy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69375194457ad0fad3a839b9e29aa0b0ed53bb54db1bfb6c3ae43d111c31ce41"},
+    {file = "contourpy-1.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a52040312b1a858b5e31ef28c2e865376a386c60c0e248370bbea2d3f3b760d"},
+    {file = "contourpy-1.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3faeb2998e4fcb256542e8a926d08da08977f7f5e62cf733f3c211c2a5586223"},
+    {file = "contourpy-1.3.0-cp310-cp310-win32.whl", hash = "sha256:36e0cff201bcb17a0a8ecc7f454fe078437fa6bda730e695a92f2d9932bd507f"},
+    {file = "contourpy-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:87ddffef1dbe5e669b5c2440b643d3fdd8622a348fe1983fad7a0f0ccb1cd67b"},
+    {file = "contourpy-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0fa4c02abe6c446ba70d96ece336e621efa4aecae43eaa9b030ae5fb92b309ad"},
+    {file = "contourpy-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:834e0cfe17ba12f79963861e0f908556b2cedd52e1f75e6578801febcc6a9f49"},
+    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbc4c3217eee163fa3984fd1567632b48d6dfd29216da3ded3d7b844a8014a66"},
+    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4865cd1d419e0c7a7bf6de1777b185eebdc51470800a9f42b9e9decf17762081"},
+    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:303c252947ab4b14c08afeb52375b26781ccd6a5ccd81abcdfc1fafd14cf93c1"},
+    {file = "contourpy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637f674226be46f6ba372fd29d9523dd977a291f66ab2a74fbeb5530bb3f445d"},
+    {file = "contourpy-1.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:76a896b2f195b57db25d6b44e7e03f221d32fe318d03ede41f8b4d9ba1bff53c"},
+    {file = "contourpy-1.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e1fd23e9d01591bab45546c089ae89d926917a66dceb3abcf01f6105d927e2cb"},
+    {file = "contourpy-1.3.0-cp311-cp311-win32.whl", hash = "sha256:d402880b84df3bec6eab53cd0cf802cae6a2ef9537e70cf75e91618a3801c20c"},
+    {file = "contourpy-1.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:6cb6cc968059db9c62cb35fbf70248f40994dfcd7aa10444bbf8b3faeb7c2d67"},
+    {file = "contourpy-1.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:570ef7cf892f0afbe5b2ee410c507ce12e15a5fa91017a0009f79f7d93a1268f"},
+    {file = "contourpy-1.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:da84c537cb8b97d153e9fb208c221c45605f73147bd4cadd23bdae915042aad6"},
+    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0be4d8425bfa755e0fd76ee1e019636ccc7c29f77a7c86b4328a9eb6a26d0639"},
+    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9c0da700bf58f6e0b65312d0a5e695179a71d0163957fa381bb3c1f72972537c"},
+    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eb8b141bb00fa977d9122636b16aa67d37fd40a3d8b52dd837e536d64b9a4d06"},
+    {file = "contourpy-1.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3634b5385c6716c258d0419c46d05c8aa7dc8cb70326c9a4fb66b69ad2b52e09"},
+    {file = "contourpy-1.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0dce35502151b6bd35027ac39ba6e5a44be13a68f55735c3612c568cac3805fd"},
+    {file = "contourpy-1.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aea348f053c645100612b333adc5983d87be69acdc6d77d3169c090d3b01dc35"},
+    {file = "contourpy-1.3.0-cp312-cp312-win32.whl", hash = "sha256:90f73a5116ad1ba7174341ef3ea5c3150ddf20b024b98fb0c3b29034752c8aeb"},
+    {file = "contourpy-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b11b39aea6be6764f84360fce6c82211a9db32a7c7de8fa6dd5397cf1d079c3b"},
+    {file = "contourpy-1.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3e1c7fa44aaae40a2247e2e8e0627f4bea3dd257014764aa644f319a5f8600e3"},
+    {file = "contourpy-1.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:364174c2a76057feef647c802652f00953b575723062560498dc7930fc9b1cb7"},
+    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32b238b3b3b649e09ce9aaf51f0c261d38644bdfa35cbaf7b263457850957a84"},
+    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d51fca85f9f7ad0b65b4b9fe800406d0d77017d7270d31ec3fb1cc07358fdea0"},
+    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:732896af21716b29ab3e988d4ce14bc5133733b85956316fb0c56355f398099b"},
+    {file = "contourpy-1.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d73f659398a0904e125280836ae6f88ba9b178b2fed6884f3b1f95b989d2c8da"},
+    {file = "contourpy-1.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c6c7c2408b7048082932cf4e641fa3b8ca848259212f51c8c59c45aa7ac18f14"},
+    {file = "contourpy-1.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f317576606de89da6b7e0861cf6061f6146ead3528acabff9236458a6ba467f8"},
+    {file = "contourpy-1.3.0-cp313-cp313-win32.whl", hash = "sha256:31cd3a85dbdf1fc002280c65caa7e2b5f65e4a973fcdf70dd2fdcb9868069294"},
+    {file = "contourpy-1.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:4553c421929ec95fb07b3aaca0fae668b2eb5a5203d1217ca7c34c063c53d087"},
+    {file = "contourpy-1.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:345af746d7766821d05d72cb8f3845dfd08dd137101a2cb9b24de277d716def8"},
+    {file = "contourpy-1.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3bb3808858a9dc68f6f03d319acd5f1b8a337e6cdda197f02f4b8ff67ad2057b"},
+    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:420d39daa61aab1221567b42eecb01112908b2cab7f1b4106a52caaec8d36973"},
+    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d63ee447261e963af02642ffcb864e5a2ee4cbfd78080657a9880b8b1868e18"},
+    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:167d6c890815e1dac9536dca00828b445d5d0df4d6a8c6adb4a7ec3166812fa8"},
+    {file = "contourpy-1.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:710a26b3dc80c0e4febf04555de66f5fd17e9cf7170a7b08000601a10570bda6"},
+    {file = "contourpy-1.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:75ee7cb1a14c617f34a51d11fa7524173e56551646828353c4af859c56b766e2"},
+    {file = "contourpy-1.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:33c92cdae89ec5135d036e7218e69b0bb2851206077251f04a6c4e0e21f03927"},
+    {file = "contourpy-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a11077e395f67ffc2c44ec2418cfebed032cd6da3022a94fc227b6faf8e2acb8"},
+    {file = "contourpy-1.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e8134301d7e204c88ed7ab50028ba06c683000040ede1d617298611f9dc6240c"},
+    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e12968fdfd5bb45ffdf6192a590bd8ddd3ba9e58360b29683c6bb71a7b41edca"},
+    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fd2a0fc506eccaaa7595b7e1418951f213cf8255be2600f1ea1b61e46a60c55f"},
+    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4cfb5c62ce023dfc410d6059c936dcf96442ba40814aefbfa575425a3a7f19dc"},
+    {file = "contourpy-1.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68a32389b06b82c2fdd68276148d7b9275b5f5cf13e5417e4252f6d1a34f72a2"},
+    {file = "contourpy-1.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:94e848a6b83da10898cbf1311a815f770acc9b6a3f2d646f330d57eb4e87592e"},
+    {file = "contourpy-1.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d78ab28a03c854a873787a0a42254a0ccb3cb133c672f645c9f9c8f3ae9d0800"},
+    {file = "contourpy-1.3.0-cp39-cp39-win32.whl", hash = "sha256:81cb5ed4952aae6014bc9d0421dec7c5835c9c8c31cdf51910b708f548cf58e5"},
+    {file = "contourpy-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:14e262f67bd7e6eb6880bc564dcda30b15e351a594657e55b7eec94b6ef72843"},
+    {file = "contourpy-1.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:fe41b41505a5a33aeaed2a613dccaeaa74e0e3ead6dd6fd3a118fb471644fd6c"},
+    {file = "contourpy-1.3.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eca7e17a65f72a5133bdbec9ecf22401c62bcf4821361ef7811faee695799779"},
+    {file = "contourpy-1.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:1ec4dc6bf570f5b22ed0d7efba0dfa9c5b9e0431aeea7581aa217542d9e809a4"},
+    {file = "contourpy-1.3.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:00ccd0dbaad6d804ab259820fa7cb0b8036bda0686ef844d24125d8287178ce0"},
+    {file = "contourpy-1.3.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ca947601224119117f7c19c9cdf6b3ab54c5726ef1d906aa4a69dfb6dd58102"},
+    {file = "contourpy-1.3.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c6ec93afeb848a0845a18989da3beca3eec2c0f852322efe21af1931147d12cb"},
+    {file = "contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4"},
 ]
 
 [package.dependencies]
-numpy = ">=1.20"
+numpy = ">=1.23"
 
 [package.extras]
 bokeh = ["bokeh", "selenium"]
 docs = ["furo", "sphinx (>=7.2)", "sphinx-copybutton"]
-mypy = ["contourpy[bokeh,docs]", "docutils-stubs", "mypy (==1.8.0)", "types-Pillow"]
+mypy = ["contourpy[bokeh,docs]", "docutils-stubs", "mypy (==1.11.1)", "types-Pillow"]
 test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
-test-no-images = ["pytest", "pytest-cov", "pytest-xdist", "wurlitzer"]
+test-no-images = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "wurlitzer"]
 
 [[package]]
 name = "cosmpy"
@@ -534,13 +555,13 @@ tqdm = ["tqdm"]
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.63.2"
+version = "1.65.0"
 description = "Common protobufs used in Google APIs"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "googleapis-common-protos-1.63.2.tar.gz", hash = "sha256:27c5abdffc4911f28101e635de1533fb4cfd2c37fbaa9174587c799fac90aa87"},
-    {file = "googleapis_common_protos-1.63.2-py2.py3-none-any.whl", hash = "sha256:27a2499c7e8aff199665b22741997e485eccc8645aa9176c7c988e6fae507945"},
+    {file = "googleapis_common_protos-1.65.0-py2.py3-none-any.whl", hash = "sha256:2972e6c496f435b92590fd54045060867f3fe9be2c82ab148fc8885035479a63"},
+    {file = "googleapis_common_protos-1.65.0.tar.gz", hash = "sha256:334a29d07cddc3aa01dee4988f9afd9b2916ee2ff49d6b757155dc0d197852c0"},
 ]
 
 [package.dependencies]
@@ -551,71 +572,71 @@ grpc = ["grpcio (>=1.44.0,<2.0.0.dev0)"]
 
 [[package]]
 name = "grpcio"
-version = "1.65.2"
+version = "1.66.1"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "grpcio-1.65.2-cp310-cp310-linux_armv7l.whl", hash = "sha256:51231a22aea830be1d955de5a15da4391b3ac8e1d7868f362c74c15a0e9f5c89"},
-    {file = "grpcio-1.65.2-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:87da0fb85ba42257e450561b0264e36abe47faae07476621ae65d8f5f60f22cd"},
-    {file = "grpcio-1.65.2-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:3a6b36e20b02ca830b15b5eb4abb437de1d42ba93353d1f76b00337108f7ce8e"},
-    {file = "grpcio-1.65.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:03fdd86ff7d9957b822b9bf1fe0ae1e21e258e9c1d5535a5e9c67de0ad45b6a8"},
-    {file = "grpcio-1.65.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6e5a67bbf8a1b3be5535802f6e9f507d1d8d38fb32de81ec7f03706d95a9126"},
-    {file = "grpcio-1.65.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:2ce639f2a2951aedbe9a3636f5730288f9b77c2627f116265d7d2789555e5662"},
-    {file = "grpcio-1.65.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b10349ceebec745a47e4339ef7c4878c9b53b82ae4b0883e16544625016d6242"},
-    {file = "grpcio-1.65.2-cp310-cp310-win32.whl", hash = "sha256:f931fe9b244dc23c7478c513c3ed94ded93da8bd1a95a4d97b21abdef644304a"},
-    {file = "grpcio-1.65.2-cp310-cp310-win_amd64.whl", hash = "sha256:0c9c865d2fdf40e7e952038a0b5e0f32b01da84ecf04943b08e8917c8ccc9cf8"},
-    {file = "grpcio-1.65.2-cp311-cp311-linux_armv7l.whl", hash = "sha256:f4b7a7d68313e252e09550bd03d9d11e460dae681cf95588a131b6b3e07d1e30"},
-    {file = "grpcio-1.65.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9ba9d4b3d4fc00b8083bb47a8c40a74ba3ea330713fdd59cf53c926c9a16b002"},
-    {file = "grpcio-1.65.2-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:b7bfcbee6b32f0e4786b7813692b3907c9e444f529126b8520cac9914479b98c"},
-    {file = "grpcio-1.65.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aa50787bc8036bd5ea9b7ebbbd2c49c78122eb9ff98d3c217a7c146313c5030"},
-    {file = "grpcio-1.65.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd7dc770926cc66050242eb6c63ca8ce12cd69010bf4ff7ea6e721d4f4b11e4d"},
-    {file = "grpcio-1.65.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c45977fdc675a8961875adab7f04b785f65d3fd9c737cd60b5e3a9b1392ad444"},
-    {file = "grpcio-1.65.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2a0cd7297abf0a02a9399edebe8c662058c7f0768bfbe859837707d389ad327f"},
-    {file = "grpcio-1.65.2-cp311-cp311-win32.whl", hash = "sha256:60fe2f90875f2bef105158e370fbbefadd179f8cd689bc2cee6844aca4ccb7bb"},
-    {file = "grpcio-1.65.2-cp311-cp311-win_amd64.whl", hash = "sha256:e0b2bf34340999c6d938107ec2cc9bce1ea59bf08e4694cfa47e782bdbd361f4"},
-    {file = "grpcio-1.65.2-cp312-cp312-linux_armv7l.whl", hash = "sha256:71fa3b7a6cef62a00014205d0e707610cfd50ae54f617d296017f10c6a9fad0d"},
-    {file = "grpcio-1.65.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8856187a359a55babfa4d49ad96f2dd7edd8be3a36b813c7a9e41ef3d763400f"},
-    {file = "grpcio-1.65.2-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:cb48342de1c3be59e6de79c6bbc01cf05562c571a3ed32f7c2e149e7934824cf"},
-    {file = "grpcio-1.65.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9b193e116e085ad4d7ef1518d79e9fedfa7688f4967f64a6246b5b196a26326a"},
-    {file = "grpcio-1.65.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ce7f4c766fecc34455357b31b1e316506ea6ac48abbb9a650843d20337a2036"},
-    {file = "grpcio-1.65.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:76125096d2a090d4acdce0f06f9511cebe1bcfbc0bd040e495563d7a8747dda1"},
-    {file = "grpcio-1.65.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4fba3ae83ef5acd111c2dd92233ff167411db84e1ff17a00c34b5428355526c5"},
-    {file = "grpcio-1.65.2-cp312-cp312-win32.whl", hash = "sha256:7fd639b0988ed5114d4b2a72ea453aafcb1439dd433c61834886b92afed9c6c1"},
-    {file = "grpcio-1.65.2-cp312-cp312-win_amd64.whl", hash = "sha256:b6bba0f973ef6fe7434834f1b63d16bab4b50879d5bb0ca6eb0495c87d5cbc78"},
-    {file = "grpcio-1.65.2-cp38-cp38-linux_armv7l.whl", hash = "sha256:510bf7ec7f44e9420bb17970fb450522666d8b1c09cdf59b735de0c2dc806b79"},
-    {file = "grpcio-1.65.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:aacfd499d23130578184057008ea5329732a5ac59a4fcb73c0467d86723d23c8"},
-    {file = "grpcio-1.65.2-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:67c5e5aa92b5832ae7a3399bce5b8562fb28686446732bfa17f97d5082e8501d"},
-    {file = "grpcio-1.65.2-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7b752471e7ff1472ddbf3035a34fd8e24f2eac4fedbdab311e8f3e0dee889f7"},
-    {file = "grpcio-1.65.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3101fa25b93f185e8cc698f8c2abee897891e6bae4f13472f66df21e8ae40d46"},
-    {file = "grpcio-1.65.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:01600b1b02fdc9d648630d3de0a4cbf7ebe5f94b40ec1f65e3fd4b94a3b052cf"},
-    {file = "grpcio-1.65.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8886d24345bf4b1693e9c09cf6a520f0baedd2af2a876f91bb508b24d0d46041"},
-    {file = "grpcio-1.65.2-cp38-cp38-win32.whl", hash = "sha256:0b2ae6868864e4b06bff89cf91730a63141327158bf0677428ef315ea1dbdb0b"},
-    {file = "grpcio-1.65.2-cp38-cp38-win_amd64.whl", hash = "sha256:c2900ad06fd8f5ad8832b1ee287caccb4a957e971b2b7983e0cd7a8e7c7098fb"},
-    {file = "grpcio-1.65.2-cp39-cp39-linux_armv7l.whl", hash = "sha256:06a7ea12a81e5e2fb17528556c7f828b90bd2aec3a645f5cd5f35f80aa59ac6a"},
-    {file = "grpcio-1.65.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5edea0ea18e9fd5326d385a4c92a1fed605454e9a2c57ff131df0a08004b7e69"},
-    {file = "grpcio-1.65.2-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:d388f093010a014d3b3ddf8185ff45c5279fd825d0b20e21c8076515ae61db31"},
-    {file = "grpcio-1.65.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5225b8ce980b598187f64436ed95ea149966d538253c28668347d331968e2386"},
-    {file = "grpcio-1.65.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:892f03939df46d0bfcf89fe1dbcc8818f93ad6f3377587e8db6c2b1f598736c2"},
-    {file = "grpcio-1.65.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:77fddf42bbca65ee4db679d0608e1ffa8b22b7f516c79665b7620be2f6357c85"},
-    {file = "grpcio-1.65.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3a3139414399078560a84203f9fe3592483d902a2af84062c571be6191143a9f"},
-    {file = "grpcio-1.65.2-cp39-cp39-win32.whl", hash = "sha256:8d6fd1206433428d0a4ba771eac70579b41a265fe835a4d8a5214c7235e69926"},
-    {file = "grpcio-1.65.2-cp39-cp39-win_amd64.whl", hash = "sha256:478725160e2cfc1bfa5ab3e7bb7c896cc182c8f57255d780007cfd6fb46e97b5"},
-    {file = "grpcio-1.65.2.tar.gz", hash = "sha256:e2c9bbb84d5517f2bccdb1836b8ee267a1757acb3cb3e575065c103220b577ac"},
+    {file = "grpcio-1.66.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:4877ba180591acdf127afe21ec1c7ff8a5ecf0fe2600f0d3c50e8c4a1cbc6492"},
+    {file = "grpcio-1.66.1-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:3750c5a00bd644c75f4507f77a804d0189d97a107eb1481945a0cf3af3e7a5ac"},
+    {file = "grpcio-1.66.1-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:a013c5fbb12bfb5f927444b477a26f1080755a931d5d362e6a9a720ca7dbae60"},
+    {file = "grpcio-1.66.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b1b24c23d51a1e8790b25514157d43f0a4dce1ac12b3f0b8e9f66a5e2c4c132f"},
+    {file = "grpcio-1.66.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7ffb8ea674d68de4cac6f57d2498fef477cef582f1fa849e9f844863af50083"},
+    {file = "grpcio-1.66.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:307b1d538140f19ccbd3aed7a93d8f71103c5d525f3c96f8616111614b14bf2a"},
+    {file = "grpcio-1.66.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1c17ebcec157cfb8dd445890a03e20caf6209a5bd4ac5b040ae9dbc59eef091d"},
+    {file = "grpcio-1.66.1-cp310-cp310-win32.whl", hash = "sha256:ef82d361ed5849d34cf09105d00b94b6728d289d6b9235513cb2fcc79f7c432c"},
+    {file = "grpcio-1.66.1-cp310-cp310-win_amd64.whl", hash = "sha256:292a846b92cdcd40ecca46e694997dd6b9be6c4c01a94a0dfb3fcb75d20da858"},
+    {file = "grpcio-1.66.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:c30aeceeaff11cd5ddbc348f37c58bcb96da8d5aa93fed78ab329de5f37a0d7a"},
+    {file = "grpcio-1.66.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8a1e224ce6f740dbb6b24c58f885422deebd7eb724aff0671a847f8951857c26"},
+    {file = "grpcio-1.66.1-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:a66fe4dc35d2330c185cfbb42959f57ad36f257e0cc4557d11d9f0a3f14311df"},
+    {file = "grpcio-1.66.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3ba04659e4fce609de2658fe4dbf7d6ed21987a94460f5f92df7579fd5d0e22"},
+    {file = "grpcio-1.66.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4573608e23f7e091acfbe3e84ac2045680b69751d8d67685ffa193a4429fedb1"},
+    {file = "grpcio-1.66.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:7e06aa1f764ec8265b19d8f00140b8c4b6ca179a6dc67aa9413867c47e1fb04e"},
+    {file = "grpcio-1.66.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3885f037eb11f1cacc41f207b705f38a44b69478086f40608959bf5ad85826dd"},
+    {file = "grpcio-1.66.1-cp311-cp311-win32.whl", hash = "sha256:97ae7edd3f3f91480e48ede5d3e7d431ad6005bfdbd65c1b56913799ec79e791"},
+    {file = "grpcio-1.66.1-cp311-cp311-win_amd64.whl", hash = "sha256:cfd349de4158d797db2bd82d2020554a121674e98fbe6b15328456b3bf2495bb"},
+    {file = "grpcio-1.66.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:a92c4f58c01c77205df6ff999faa008540475c39b835277fb8883b11cada127a"},
+    {file = "grpcio-1.66.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:fdb14bad0835914f325349ed34a51940bc2ad965142eb3090081593c6e347be9"},
+    {file = "grpcio-1.66.1-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:f03a5884c56256e08fd9e262e11b5cfacf1af96e2ce78dc095d2c41ccae2c80d"},
+    {file = "grpcio-1.66.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ca2559692d8e7e245d456877a85ee41525f3ed425aa97eb7a70fc9a79df91a0"},
+    {file = "grpcio-1.66.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84ca1be089fb4446490dd1135828bd42a7c7f8421e74fa581611f7afdf7ab761"},
+    {file = "grpcio-1.66.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:d639c939ad7c440c7b2819a28d559179a4508783f7e5b991166f8d7a34b52815"},
+    {file = "grpcio-1.66.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b9feb4e5ec8dc2d15709f4d5fc367794d69277f5d680baf1910fc9915c633524"},
+    {file = "grpcio-1.66.1-cp312-cp312-win32.whl", hash = "sha256:7101db1bd4cd9b880294dec41a93fcdce465bdbb602cd8dc5bd2d6362b618759"},
+    {file = "grpcio-1.66.1-cp312-cp312-win_amd64.whl", hash = "sha256:b0aa03d240b5539648d996cc60438f128c7f46050989e35b25f5c18286c86734"},
+    {file = "grpcio-1.66.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:ecfe735e7a59e5a98208447293ff8580e9db1e890e232b8b292dc8bd15afc0d2"},
+    {file = "grpcio-1.66.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:4825a3aa5648010842e1c9d35a082187746aa0cdbf1b7a2a930595a94fb10fce"},
+    {file = "grpcio-1.66.1-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:f517fd7259fe823ef3bd21e508b653d5492e706e9f0ef82c16ce3347a8a5620c"},
+    {file = "grpcio-1.66.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f1fe60d0772831d96d263b53d83fb9a3d050a94b0e94b6d004a5ad111faa5b5b"},
+    {file = "grpcio-1.66.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31a049daa428f928f21090403e5d18ea02670e3d5d172581670be006100db9ef"},
+    {file = "grpcio-1.66.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:6f914386e52cbdeb5d2a7ce3bf1fdfacbe9d818dd81b6099a05b741aaf3848bb"},
+    {file = "grpcio-1.66.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bff2096bdba686019fb32d2dde45b95981f0d1490e054400f70fc9a8af34b49d"},
+    {file = "grpcio-1.66.1-cp38-cp38-win32.whl", hash = "sha256:aa8ba945c96e73de29d25331b26f3e416e0c0f621e984a3ebdb2d0d0b596a3b3"},
+    {file = "grpcio-1.66.1-cp38-cp38-win_amd64.whl", hash = "sha256:161d5c535c2bdf61b95080e7f0f017a1dfcb812bf54093e71e5562b16225b4ce"},
+    {file = "grpcio-1.66.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:d0cd7050397b3609ea51727b1811e663ffda8bda39c6a5bb69525ef12414b503"},
+    {file = "grpcio-1.66.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0e6c9b42ded5d02b6b1fea3a25f036a2236eeb75d0579bfd43c0018c88bf0a3e"},
+    {file = "grpcio-1.66.1-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:c9f80f9fad93a8cf71c7f161778ba47fd730d13a343a46258065c4deb4b550c0"},
+    {file = "grpcio-1.66.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5dd67ed9da78e5121efc5c510f0122a972216808d6de70953a740560c572eb44"},
+    {file = "grpcio-1.66.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48b0d92d45ce3be2084b92fb5bae2f64c208fea8ceed7fccf6a7b524d3c4942e"},
+    {file = "grpcio-1.66.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:4d813316d1a752be6f5c4360c49f55b06d4fe212d7df03253dfdae90c8a402bb"},
+    {file = "grpcio-1.66.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9c9bebc6627873ec27a70fc800f6083a13c70b23a5564788754b9ee52c5aef6c"},
+    {file = "grpcio-1.66.1-cp39-cp39-win32.whl", hash = "sha256:30a1c2cf9390c894c90bbc70147f2372130ad189cffef161f0432d0157973f45"},
+    {file = "grpcio-1.66.1-cp39-cp39-win_amd64.whl", hash = "sha256:17663598aadbedc3cacd7bbde432f541c8e07d2496564e22b214b22c7523dac8"},
+    {file = "grpcio-1.66.1.tar.gz", hash = "sha256:35334f9c9745add3e357e3372756fd32d925bd52c41da97f4dfdafbde0bf0ee2"},
 ]
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.65.2)"]
+protobuf = ["grpcio-tools (>=1.66.1)"]
 
 [[package]]
 name = "holidays"
-version = "0.53"
+version = "0.55"
 description = "Generate and work with holidays in Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "holidays-0.53-py3-none-any.whl", hash = "sha256:371080faaa1c85fef49a64b16c52c2ec5cc9674360cc9fafad312eba74f3de1a"},
-    {file = "holidays-0.53.tar.gz", hash = "sha256:ed8c935d35ad3c3e0866cd49256a51fb3e63d4ba506ca7ebbf07819feb055bfa"},
+    {file = "holidays-0.55-py3-none-any.whl", hash = "sha256:50a6aa737a964dd736bb0259ddabcf48e9516caeca3c11742233a0effb6ddfb4"},
+    {file = "holidays-0.55.tar.gz", hash = "sha256:d2eba8b05171fc5cfdff86995093a43b81af46abfe821d716c54329fa06c0a1a"},
 ]
 
 [package.dependencies]
@@ -623,29 +644,33 @@ python-dateutil = "*"
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.8"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
+    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
 ]
 
 [[package]]
 name = "importlib-resources"
-version = "6.4.0"
+version = "6.4.4"
 description = "Read resources from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-6.4.0-py3-none-any.whl", hash = "sha256:50d10f043df931902d4194ea07ec57960f66a80449ff867bfe782b4c486ba78c"},
-    {file = "importlib_resources-6.4.0.tar.gz", hash = "sha256:cdb2b453b8046ca4e3798eb1d84f3cce1446a0e8e7b5ef4efb600f19fc398145"},
+    {file = "importlib_resources-6.4.4-py3-none-any.whl", hash = "sha256:dda242603d1c9cd836c3368b1174ed74cb4049ecd209e7a1a0104620c18c5c11"},
+    {file = "importlib_resources-6.4.4.tar.gz", hash = "sha256:20600c8b7361938dc0bb2d5ec0297802e575df486f5a544fa414da65e13721f7"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
+type = ["pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -933,40 +958,51 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.9.1"
+version = "3.9.2"
 description = "Python plotting package"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "matplotlib-3.9.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:7ccd6270066feb9a9d8e0705aa027f1ff39f354c72a87efe8fa07632f30fc6bb"},
-    {file = "matplotlib-3.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:591d3a88903a30a6d23b040c1e44d1afdd0d778758d07110eb7596f811f31842"},
-    {file = "matplotlib-3.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd2a59ff4b83d33bca3b5ec58203cc65985367812cb8c257f3e101632be86d92"},
-    {file = "matplotlib-3.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fc001516ffcf1a221beb51198b194d9230199d6842c540108e4ce109ac05cc0"},
-    {file = "matplotlib-3.9.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:83c6a792f1465d174c86d06f3ae85a8fe36e6f5964633ae8106312ec0921fdf5"},
-    {file = "matplotlib-3.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:421851f4f57350bcf0811edd754a708d2275533e84f52f6760b740766c6747a7"},
-    {file = "matplotlib-3.9.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b3fce58971b465e01b5c538f9d44915640c20ec5ff31346e963c9e1cd66fa812"},
-    {file = "matplotlib-3.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a973c53ad0668c53e0ed76b27d2eeeae8799836fd0d0caaa4ecc66bf4e6676c0"},
-    {file = "matplotlib-3.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82cd5acf8f3ef43f7532c2f230249720f5dc5dd40ecafaf1c60ac8200d46d7eb"},
-    {file = "matplotlib-3.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab38a4f3772523179b2f772103d8030215b318fef6360cb40558f585bf3d017f"},
-    {file = "matplotlib-3.9.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2315837485ca6188a4b632c5199900e28d33b481eb083663f6a44cfc8987ded3"},
-    {file = "matplotlib-3.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:a0c977c5c382f6696caf0bd277ef4f936da7e2aa202ff66cad5f0ac1428ee15b"},
-    {file = "matplotlib-3.9.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:565d572efea2b94f264dd86ef27919515aa6d629252a169b42ce5f570db7f37b"},
-    {file = "matplotlib-3.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d397fd8ccc64af2ec0af1f0efc3bacd745ebfb9d507f3f552e8adb689ed730a"},
-    {file = "matplotlib-3.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26040c8f5121cd1ad712abffcd4b5222a8aec3a0fe40bc8542c94331deb8780d"},
-    {file = "matplotlib-3.9.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d12cb1837cffaac087ad6b44399d5e22b78c729de3cdae4629e252067b705e2b"},
-    {file = "matplotlib-3.9.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0e835c6988edc3d2d08794f73c323cc62483e13df0194719ecb0723b564e0b5c"},
-    {file = "matplotlib-3.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:44a21d922f78ce40435cb35b43dd7d573cf2a30138d5c4b709d19f00e3907fd7"},
-    {file = "matplotlib-3.9.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:0c584210c755ae921283d21d01f03a49ef46d1afa184134dd0f95b0202ee6f03"},
-    {file = "matplotlib-3.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:11fed08f34fa682c2b792942f8902e7aefeed400da71f9e5816bea40a7ce28fe"},
-    {file = "matplotlib-3.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0000354e32efcfd86bda75729716b92f5c2edd5b947200be9881f0a671565c33"},
-    {file = "matplotlib-3.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4db17fea0ae3aceb8e9ac69c7e3051bae0b3d083bfec932240f9bf5d0197a049"},
-    {file = "matplotlib-3.9.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:208cbce658b72bf6a8e675058fbbf59f67814057ae78165d8a2f87c45b48d0ff"},
-    {file = "matplotlib-3.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:dc23f48ab630474264276be156d0d7710ac6c5a09648ccdf49fef9200d8cbe80"},
-    {file = "matplotlib-3.9.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3fda72d4d472e2ccd1be0e9ccb6bf0d2eaf635e7f8f51d737ed7e465ac020cb3"},
-    {file = "matplotlib-3.9.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:84b3ba8429935a444f1fdc80ed930babbe06725bcf09fbeb5c8757a2cd74af04"},
-    {file = "matplotlib-3.9.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b918770bf3e07845408716e5bbda17eadfc3fcbd9307dc67f37d6cf834bb3d98"},
-    {file = "matplotlib-3.9.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:f1f2e5d29e9435c97ad4c36fb6668e89aee13d48c75893e25cef064675038ac9"},
-    {file = "matplotlib-3.9.1.tar.gz", hash = "sha256:de06b19b8db95dd33d0dc17c926c7c9ebed9f572074b6fac4f65068a6814d010"},
+    {file = "matplotlib-3.9.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:9d78bbc0cbc891ad55b4f39a48c22182e9bdaea7fc0e5dbd364f49f729ca1bbb"},
+    {file = "matplotlib-3.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c375cc72229614632c87355366bdf2570c2dac01ac66b8ad048d2dabadf2d0d4"},
+    {file = "matplotlib-3.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d94ff717eb2bd0b58fe66380bd8b14ac35f48a98e7c6765117fe67fb7684e64"},
+    {file = "matplotlib-3.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab68d50c06938ef28681073327795c5db99bb4666214d2d5f880ed11aeaded66"},
+    {file = "matplotlib-3.9.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:65aacf95b62272d568044531e41de26285d54aec8cb859031f511f84bd8b495a"},
+    {file = "matplotlib-3.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:3fd595f34aa8a55b7fc8bf9ebea8aa665a84c82d275190a61118d33fbc82ccae"},
+    {file = "matplotlib-3.9.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d8dd059447824eec055e829258ab092b56bb0579fc3164fa09c64f3acd478772"},
+    {file = "matplotlib-3.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c797dac8bb9c7a3fd3382b16fe8f215b4cf0f22adccea36f1545a6d7be310b41"},
+    {file = "matplotlib-3.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d719465db13267bcef19ea8954a971db03b9f48b4647e3860e4bc8e6ed86610f"},
+    {file = "matplotlib-3.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8912ef7c2362f7193b5819d17dae8629b34a95c58603d781329712ada83f9447"},
+    {file = "matplotlib-3.9.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7741f26a58a240f43bee74965c4882b6c93df3e7eb3de160126d8c8f53a6ae6e"},
+    {file = "matplotlib-3.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:ae82a14dab96fbfad7965403c643cafe6515e386de723e498cf3eeb1e0b70cc7"},
+    {file = "matplotlib-3.9.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ac43031375a65c3196bee99f6001e7fa5bdfb00ddf43379d3c0609bdca042df9"},
+    {file = "matplotlib-3.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be0fc24a5e4531ae4d8e858a1a548c1fe33b176bb13eff7f9d0d38ce5112a27d"},
+    {file = "matplotlib-3.9.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf81de2926c2db243c9b2cbc3917619a0fc85796c6ba4e58f541df814bbf83c7"},
+    {file = "matplotlib-3.9.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6ee45bc4245533111ced13f1f2cace1e7f89d1c793390392a80c139d6cf0e6c"},
+    {file = "matplotlib-3.9.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:306c8dfc73239f0e72ac50e5a9cf19cc4e8e331dd0c54f5e69ca8758550f1e1e"},
+    {file = "matplotlib-3.9.2-cp312-cp312-win_amd64.whl", hash = "sha256:5413401594cfaff0052f9d8b1aafc6d305b4bd7c4331dccd18f561ff7e1d3bd3"},
+    {file = "matplotlib-3.9.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:18128cc08f0d3cfff10b76baa2f296fc28c4607368a8402de61bb3f2eb33c7d9"},
+    {file = "matplotlib-3.9.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4876d7d40219e8ae8bb70f9263bcbe5714415acfdf781086601211335e24f8aa"},
+    {file = "matplotlib-3.9.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d9f07a80deab4bb0b82858a9e9ad53d1382fd122be8cde11080f4e7dfedb38b"},
+    {file = "matplotlib-3.9.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7c0410f181a531ec4e93bbc27692f2c71a15c2da16766f5ba9761e7ae518413"},
+    {file = "matplotlib-3.9.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:909645cce2dc28b735674ce0931a4ac94e12f5b13f6bb0b5a5e65e7cea2c192b"},
+    {file = "matplotlib-3.9.2-cp313-cp313-win_amd64.whl", hash = "sha256:f32c7410c7f246838a77d6d1eff0c0f87f3cb0e7c4247aebea71a6d5a68cab49"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:37e51dd1c2db16ede9cfd7b5cabdfc818b2c6397c83f8b10e0e797501c963a03"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b82c5045cebcecd8496a4d694d43f9cc84aeeb49fe2133e036b207abe73f4d30"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f053c40f94bc51bc03832a41b4f153d83f2062d88c72b5e79997072594e97e51"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbe196377a8248972f5cede786d4c5508ed5f5ca4a1e09b44bda889958b33f8c"},
+    {file = "matplotlib-3.9.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5816b1e1fe8c192cbc013f8f3e3368ac56fbecf02fb41b8f8559303f24c5015e"},
+    {file = "matplotlib-3.9.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:cef2a73d06601437be399908cf13aee74e86932a5ccc6ccdf173408ebc5f6bb2"},
+    {file = "matplotlib-3.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e0830e188029c14e891fadd99702fd90d317df294c3298aad682739c5533721a"},
+    {file = "matplotlib-3.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03ba9c1299c920964e8d3857ba27173b4dbb51ca4bab47ffc2c2ba0eb5e2cbc5"},
+    {file = "matplotlib-3.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cd93b91ab47a3616b4d3c42b52f8363b88ca021e340804c6ab2536344fad9ca"},
+    {file = "matplotlib-3.9.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6d1ce5ed2aefcdce11904fc5bbea7d9c21fff3d5f543841edf3dea84451a09ea"},
+    {file = "matplotlib-3.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:b2696efdc08648536efd4e1601b5fd491fd47f4db97a5fbfd175549a7365c1b2"},
+    {file = "matplotlib-3.9.2-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:d52a3b618cb1cbb769ce2ee1dcdb333c3ab6e823944e9a2d36e37253815f9556"},
+    {file = "matplotlib-3.9.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:039082812cacd6c6bec8e17a9c1e6baca230d4116d522e81e1f63a74d01d2e21"},
+    {file = "matplotlib-3.9.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6758baae2ed64f2331d4fd19be38b7b4eae3ecec210049a26b6a4f3ae1c85dcc"},
+    {file = "matplotlib-3.9.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:050598c2b29e0b9832cde72bcf97627bf00262adbc4a54e2b856426bb2ef0697"},
+    {file = "matplotlib-3.9.2.tar.gz", hash = "sha256:96ab43906269ca64a6366934106fa01534454a69e471b7bf3d79083981aaab92"},
 ]
 
 [package.dependencies]
@@ -1031,38 +1067,38 @@ tests = ["pytest (>=4.6)"]
 
 [[package]]
 name = "mypy"
-version = "1.11.1"
+version = "1.11.2"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.11.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a32fc80b63de4b5b3e65f4be82b4cfa362a46702672aa6a0f443b4689af7008c"},
-    {file = "mypy-1.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c1952f5ea8a5a959b05ed5f16452fddadbaae48b5d39235ab4c3fc444d5fd411"},
-    {file = "mypy-1.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1e30dc3bfa4e157e53c1d17a0dad20f89dc433393e7702b813c10e200843b03"},
-    {file = "mypy-1.11.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2c63350af88f43a66d3dfeeeb8d77af34a4f07d760b9eb3a8697f0386c7590b4"},
-    {file = "mypy-1.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:a831671bad47186603872a3abc19634f3011d7f83b083762c942442d51c58d58"},
-    {file = "mypy-1.11.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7b6343d338390bb946d449677726edf60102a1c96079b4f002dedff375953fc5"},
-    {file = "mypy-1.11.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e4fe9f4e5e521b458d8feb52547f4bade7ef8c93238dfb5bbc790d9ff2d770ca"},
-    {file = "mypy-1.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:886c9dbecc87b9516eff294541bf7f3655722bf22bb898ee06985cd7269898de"},
-    {file = "mypy-1.11.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fca4a60e1dd9fd0193ae0067eaeeb962f2d79e0d9f0f66223a0682f26ffcc809"},
-    {file = "mypy-1.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:0bd53faf56de9643336aeea1c925012837432b5faf1701ccca7fde70166ccf72"},
-    {file = "mypy-1.11.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f39918a50f74dc5969807dcfaecafa804fa7f90c9d60506835036cc1bc891dc8"},
-    {file = "mypy-1.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0bc71d1fb27a428139dd78621953effe0d208aed9857cb08d002280b0422003a"},
-    {file = "mypy-1.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b868d3bcff720dd7217c383474008ddabaf048fad8d78ed948bb4b624870a417"},
-    {file = "mypy-1.11.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a707ec1527ffcdd1c784d0924bf5cb15cd7f22683b919668a04d2b9c34549d2e"},
-    {file = "mypy-1.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:64f4a90e3ea07f590c5bcf9029035cf0efeae5ba8be511a8caada1a4893f5525"},
-    {file = "mypy-1.11.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:749fd3213916f1751fff995fccf20c6195cae941dc968f3aaadf9bb4e430e5a2"},
-    {file = "mypy-1.11.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b639dce63a0b19085213ec5fdd8cffd1d81988f47a2dec7100e93564f3e8fb3b"},
-    {file = "mypy-1.11.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c956b49c5d865394d62941b109728c5c596a415e9c5b2be663dd26a1ff07bc0"},
-    {file = "mypy-1.11.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:45df906e8b6804ef4b666af29a87ad9f5921aad091c79cc38e12198e220beabd"},
-    {file = "mypy-1.11.1-cp38-cp38-win_amd64.whl", hash = "sha256:d44be7551689d9d47b7abc27c71257adfdb53f03880841a5db15ddb22dc63edb"},
-    {file = "mypy-1.11.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2684d3f693073ab89d76da8e3921883019ea8a3ec20fa5d8ecca6a2db4c54bbe"},
-    {file = "mypy-1.11.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:79c07eb282cb457473add5052b63925e5cc97dfab9812ee65a7c7ab5e3cb551c"},
-    {file = "mypy-1.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11965c2f571ded6239977b14deebd3f4c3abd9a92398712d6da3a772974fad69"},
-    {file = "mypy-1.11.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a2b43895a0f8154df6519706d9bca8280cda52d3d9d1514b2d9c3e26792a0b74"},
-    {file = "mypy-1.11.1-cp39-cp39-win_amd64.whl", hash = "sha256:1a81cf05975fd61aec5ae16501a091cfb9f605dc3e3c878c0da32f250b74760b"},
-    {file = "mypy-1.11.1-py3-none-any.whl", hash = "sha256:0624bdb940255d2dd24e829d99a13cfeb72e4e9031f9492148f410ed30bcab54"},
-    {file = "mypy-1.11.1.tar.gz", hash = "sha256:f404a0b069709f18bbdb702eb3dcfe51910602995de00bd39cea3050b5772d08"},
+    {file = "mypy-1.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d42a6dd818ffce7be66cce644f1dff482f1d97c53ca70908dff0b9ddc120b77a"},
+    {file = "mypy-1.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:801780c56d1cdb896eacd5619a83e427ce436d86a3bdf9112527f24a66618fef"},
+    {file = "mypy-1.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41ea707d036a5307ac674ea172875f40c9d55c5394f888b168033177fce47383"},
+    {file = "mypy-1.11.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6e658bd2d20565ea86da7d91331b0eed6d2eee22dc031579e6297f3e12c758c8"},
+    {file = "mypy-1.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:478db5f5036817fe45adb7332d927daa62417159d49783041338921dcf646fc7"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:75746e06d5fa1e91bfd5432448d00d34593b52e7e91a187d981d08d1f33d4385"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a976775ab2256aadc6add633d44f100a2517d2388906ec4f13231fafbb0eccca"},
+    {file = "mypy-1.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd953f221ac1379050a8a646585a29574488974f79d8082cedef62744f0a0104"},
+    {file = "mypy-1.11.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:57555a7715c0a34421013144a33d280e73c08df70f3a18a552938587ce9274f4"},
+    {file = "mypy-1.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:36383a4fcbad95f2657642a07ba22ff797de26277158f1cc7bd234821468b1b6"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e8960dbbbf36906c5c0b7f4fbf2f0c7ffb20f4898e6a879fcf56a41a08b0d318"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06d26c277962f3fb50e13044674aa10553981ae514288cb7d0a738f495550b36"},
+    {file = "mypy-1.11.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e7184632d89d677973a14d00ae4d03214c8bc301ceefcdaf5c474866814c987"},
+    {file = "mypy-1.11.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3a66169b92452f72117e2da3a576087025449018afc2d8e9bfe5ffab865709ca"},
+    {file = "mypy-1.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:969ea3ef09617aff826885a22ece0ddef69d95852cdad2f60c8bb06bf1f71f70"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:37c7fa6121c1cdfcaac97ce3d3b5588e847aa79b580c1e922bb5d5d2902df19b"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a8a53bc3ffbd161b5b2a4fff2f0f1e23a33b0168f1c0778ec70e1a3d66deb86"},
+    {file = "mypy-1.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ff93107f01968ed834f4256bc1fc4475e2fecf6c661260066a985b52741ddce"},
+    {file = "mypy-1.11.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:edb91dded4df17eae4537668b23f0ff6baf3707683734b6a818d5b9d0c0c31a1"},
+    {file = "mypy-1.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:ee23de8530d99b6db0573c4ef4bd8f39a2a6f9b60655bf7a1357e585a3486f2b"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:801ca29f43d5acce85f8e999b1e431fb479cb02d0e11deb7d2abb56bdaf24fd6"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af8d155170fcf87a2afb55b35dc1a0ac21df4431e7d96717621962e4b9192e70"},
+    {file = "mypy-1.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7821776e5c4286b6a13138cc935e2e9b6fde05e081bdebf5cdb2bb97c9df81d"},
+    {file = "mypy-1.11.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:539c570477a96a4e6fb718b8d5c3e0c0eba1f485df13f86d2970c91f0673148d"},
+    {file = "mypy-1.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:3f14cd3d386ac4d05c5a39a51b84387403dadbd936e17cb35882134d4f8f0d24"},
+    {file = "mypy-1.11.2-py3-none-any.whl", hash = "sha256:b499bc07dbdcd3de92b0a8b29fdf592c111276f6a12fe29c30f6c417dd546d12"},
+    {file = "mypy-1.11.2.tar.gz", hash = "sha256:7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79"},
 ]
 
 [package.dependencies]
@@ -1089,12 +1125,12 @@ files = [
 
 [[package]]
 name = "nada-dsl"
-version = "0.5.0"
+version = "0.6.0"
 description = "Nillion Nada DSL to create Nillion MPC programs."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "nada_dsl-0.5.0-py3-none-any.whl", hash = "sha256:3ff7b5b825a8a9d9414102d75fa3087b124dc97d5f74d3a33710cfa364babd7b"},
+    {file = "nada_dsl-0.6.0-py3-none-any.whl", hash = "sha256:dd0484953dc3237bf14987840904fe7bc22d4112e6da679c5f550422ddb0d3ad"},
 ]
 
 [package.dependencies]
@@ -1104,30 +1140,30 @@ richreports = ">=0.2,<1.0"
 sortedcontainers = ">=2.4,<3.0"
 
 [package.extras]
-docs = ["sphinx (>=5,<8)", "sphinx-rtd-theme (>=1.0,<2.1)", "toml (>=0.10.2,<0.11.0)"]
+docs = ["sphinx (>=5,<9)", "sphinx-rtd-theme (>=1.0,<2.1)", "toml (>=0.10.2,<0.11.0)"]
 lint = ["pylint (>=2.17,<3.3)"]
 test = ["pytest (>=7.4,<9.0)", "pytest-cov (>=4,<6)"]
 
 [[package]]
 name = "nada-numpy"
-version = "0.4.0"
+version = "0.5.0"
 description = "Nada-Numpy is a Python library designed for algebraic operations on NumPy-like array objects on top of Nada DSL and Nillion Network."
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "nada_numpy-0.4.0-py3-none-any.whl", hash = "sha256:c995f199b7840c8aecb5524ead10aed075893623e5edd6df2db32b3da536ee17"},
-    {file = "nada_numpy-0.4.0.tar.gz", hash = "sha256:423521ea8f3c21ac8ab51b30c25fe64ba8d2449e8f8c3511d47bd0f0e5d59966"},
+    {file = "nada_numpy-0.5.0-py3-none-any.whl", hash = "sha256:ff03f08f93ea7e08153ee0d3e74d1af9ab4d5a880c2d122fb67ec5dbb9627b9b"},
+    {file = "nada_numpy-0.5.0.tar.gz", hash = "sha256:e795dfb35d627faae2e923b836a36893eb46cd7927659ff1479e2edbf213dade"},
 ]
 
 [package.dependencies]
-nada-dsl = ">=0.5.0,<0.6.0"
+nada-dsl = ">=0.6.0,<0.7.0"
 nillion-python-helpers = ">=0.2.3,<0.3.0"
 numpy = ">=1.26.4,<2.0.0"
-py-nillion-client = ">=0.5.0,<0.6.0"
+py-nillion-client = ">=0.6.0,<0.7.0"
 
 [package.extras]
 examples = ["scikit-learn (>=1.5.1,<2.0.0)"]
-linter = ["black (>=24.4.2,<25.0.0)", "isort (>=5.13.2,<6.0.0)"]
+linter = ["black (==24.8.0)", "isort (>=5.13.2,<6.0.0)"]
 
 [[package]]
 name = "networkx"
@@ -1330,14 +1366,14 @@ files = [
 
 [[package]]
 name = "nvidia-nvjitlink-cu12"
-version = "12.5.82"
+version = "12.6.68"
 description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 files = [
-    {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_aarch64.whl", hash = "sha256:98103729cc5226e13ca319a10bbf9433bbbd44ef64fe72f45f067cacc14b8d27"},
-    {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f9b37bc5c8cf7509665cb6ada5aaa0ce65618f2332b7d3e78e9790511f111212"},
-    {file = "nvidia_nvjitlink_cu12-12.5.82-py3-none-win_amd64.whl", hash = "sha256:e782564d705ff0bf61ac3e1bf730166da66dd2fe9012f111ede5fc49b64ae697"},
+    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-manylinux2014_aarch64.whl", hash = "sha256:b3fd0779845f68b92063ab1393abab1ed0a23412fc520df79a8190d098b5cd6b"},
+    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-manylinux2014_x86_64.whl", hash = "sha256:125a6c2a44e96386dda634e13d944e60b07a0402d391a070e8fb4104b34ea1ab"},
+    {file = "nvidia_nvjitlink_cu12-12.6.68-py3-none-win_amd64.whl", hash = "sha256:a55744c98d70317c5e23db14866a8cc2b733f7324509e941fc96276f9f37801d"},
 ]
 
 [[package]]
@@ -1642,15 +1678,15 @@ files = [
 
 [[package]]
 name = "py-nillion-client"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python client for Nillion network and utilities."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "py_nillion_client-0.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:cda0c4c6a5ee364fd58003628a6247d0110d7f7d3691d1005bfc77d828c97932"},
-    {file = "py_nillion_client-0.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:3e185edff4c0ebedd008da1703e05bfba4da05bd67714d25d8aafcb835038803"},
-    {file = "py_nillion_client-0.5.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d662cdc9cc637f0f444b7840715dd46c723c52b5935200839e96f3575e96ed74"},
-    {file = "py_nillion_client-0.5.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d0d47ff6547a0d0390f35f195e73fedfbccf6e054b07016f2f375634daca7a1"},
+    {file = "py_nillion_client-0.6.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8921284ceb9ae6e01c509ca1d9802d5fafdbc2906a4b9afac29551f5ee976d62"},
+    {file = "py_nillion_client-0.6.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e8141f3010c4914ce648b53c8b798f8d8e79370b29cee13cc9dcc642f9e45487"},
+    {file = "py_nillion_client-0.6.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:240d5bf784c6007eed8a082c532f11ba92af8191c81cb611ae1964e7ef89fa1a"},
+    {file = "py_nillion_client-0.6.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a6ddc4c1170895ba140691c7cab3e87e3ec7cd2836e851a6458fc2a670bf7e9"},
 ]
 
 [package.dependencies]
@@ -1731,13 +1767,13 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pyparsing"
-version = "3.1.2"
+version = "3.1.4"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 optional = false
 python-versions = ">=3.6.8"
 files = [
-    {file = "pyparsing-3.1.2-py3-none-any.whl", hash = "sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742"},
-    {file = "pyparsing-3.1.2.tar.gz", hash = "sha256:a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad"},
+    {file = "pyparsing-3.1.4-py3-none-any.whl", hash = "sha256:a6a7ee4235a3f944aa1fa2249307708f893fe5717dc603503c6c7969c070fb7c"},
+    {file = "pyparsing-3.1.4.tar.gz", hash = "sha256:f86ec8d1a83f11977c9a6ea7598e8c27fc5cddfa5b07ea2241edbbde1d7bc032"},
 ]
 
 [package.extras]
@@ -1878,114 +1914,114 @@ test = ["pytest (>=7.4,<8.0)", "pytest-cov (>=4.0,<5.0)"]
 
 [[package]]
 name = "rpds-py"
-version = "0.19.1"
+version = "0.20.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "rpds_py-0.19.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:aaf71f95b21f9dc708123335df22e5a2fef6307e3e6f9ed773b2e0938cc4d491"},
-    {file = "rpds_py-0.19.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ca0dda0c5715efe2ab35bb83f813f681ebcd2840d8b1b92bfc6fe3ab382fae4a"},
-    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81db2e7282cc0487f500d4db203edc57da81acde9e35f061d69ed983228ffe3b"},
-    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1a8dfa125b60ec00c7c9baef945bb04abf8ac772d8ebefd79dae2a5f316d7850"},
-    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:271accf41b02687cef26367c775ab220372ee0f4925591c6796e7c148c50cab5"},
-    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9bc4161bd3b970cd6a6fcda70583ad4afd10f2750609fb1f3ca9505050d4ef3"},
-    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0cf2a0dbb5987da4bd92a7ca727eadb225581dd9681365beba9accbe5308f7d"},
-    {file = "rpds_py-0.19.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b5e28e56143750808c1c79c70a16519e9bc0a68b623197b96292b21b62d6055c"},
-    {file = "rpds_py-0.19.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c7af6f7b80f687b33a4cdb0a785a5d4de1fb027a44c9a049d8eb67d5bfe8a687"},
-    {file = "rpds_py-0.19.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e429fc517a1c5e2a70d576077231538a98d59a45dfc552d1ac45a132844e6dfb"},
-    {file = "rpds_py-0.19.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d2dbd8f4990d4788cb122f63bf000357533f34860d269c1a8e90ae362090ff3a"},
-    {file = "rpds_py-0.19.1-cp310-none-win32.whl", hash = "sha256:e0f9d268b19e8f61bf42a1da48276bcd05f7ab5560311f541d22557f8227b866"},
-    {file = "rpds_py-0.19.1-cp310-none-win_amd64.whl", hash = "sha256:df7c841813f6265e636fe548a49664c77af31ddfa0085515326342a751a6ba51"},
-    {file = "rpds_py-0.19.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:902cf4739458852fe917104365ec0efbea7d29a15e4276c96a8d33e6ed8ec137"},
-    {file = "rpds_py-0.19.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f3d73022990ab0c8b172cce57c69fd9a89c24fd473a5e79cbce92df87e3d9c48"},
-    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3837c63dd6918a24de6c526277910e3766d8c2b1627c500b155f3eecad8fad65"},
-    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cdb7eb3cf3deb3dd9e7b8749323b5d970052711f9e1e9f36364163627f96da58"},
-    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26ab43b6d65d25b1a333c8d1b1c2f8399385ff683a35ab5e274ba7b8bb7dc61c"},
-    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75130df05aae7a7ac171b3b5b24714cffeabd054ad2ebc18870b3aa4526eba23"},
-    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c34f751bf67cab69638564eee34023909380ba3e0d8ee7f6fe473079bf93f09b"},
-    {file = "rpds_py-0.19.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f2671cb47e50a97f419a02cd1e0c339b31de017b033186358db92f4d8e2e17d8"},
-    {file = "rpds_py-0.19.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c73254c256081704dba0a333457e2fb815364018788f9b501efe7c5e0ada401"},
-    {file = "rpds_py-0.19.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4383beb4a29935b8fa28aca8fa84c956bf545cb0c46307b091b8d312a9150e6a"},
-    {file = "rpds_py-0.19.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dbceedcf4a9329cc665452db1aaf0845b85c666e4885b92ee0cddb1dbf7e052a"},
-    {file = "rpds_py-0.19.1-cp311-none-win32.whl", hash = "sha256:f0a6d4a93d2a05daec7cb885157c97bbb0be4da739d6f9dfb02e101eb40921cd"},
-    {file = "rpds_py-0.19.1-cp311-none-win_amd64.whl", hash = "sha256:c149a652aeac4902ecff2dd93c3b2681c608bd5208c793c4a99404b3e1afc87c"},
-    {file = "rpds_py-0.19.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:56313be667a837ff1ea3508cebb1ef6681d418fa2913a0635386cf29cff35165"},
-    {file = "rpds_py-0.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d1d7539043b2b31307f2c6c72957a97c839a88b2629a348ebabe5aa8b626d6b"},
-    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e1dc59a5e7bc7f44bd0c048681f5e05356e479c50be4f2c1a7089103f1621d5"},
-    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b8f78398e67a7227aefa95f876481485403eb974b29e9dc38b307bb6eb2315ea"},
-    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ef07a0a1d254eeb16455d839cef6e8c2ed127f47f014bbda64a58b5482b6c836"},
-    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8124101e92c56827bebef084ff106e8ea11c743256149a95b9fd860d3a4f331f"},
-    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08ce9c95a0b093b7aec75676b356a27879901488abc27e9d029273d280438505"},
-    {file = "rpds_py-0.19.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0b02dd77a2de6e49078c8937aadabe933ceac04b41c5dde5eca13a69f3cf144e"},
-    {file = "rpds_py-0.19.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4dd02e29c8cbed21a1875330b07246b71121a1c08e29f0ee3db5b4cfe16980c4"},
-    {file = "rpds_py-0.19.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9c7042488165f7251dc7894cd533a875d2875af6d3b0e09eda9c4b334627ad1c"},
-    {file = "rpds_py-0.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f809a17cc78bd331e137caa25262b507225854073fd319e987bd216bed911b7c"},
-    {file = "rpds_py-0.19.1-cp312-none-win32.whl", hash = "sha256:3ddab996807c6b4227967fe1587febade4e48ac47bb0e2d3e7858bc621b1cace"},
-    {file = "rpds_py-0.19.1-cp312-none-win_amd64.whl", hash = "sha256:32e0db3d6e4f45601b58e4ac75c6f24afbf99818c647cc2066f3e4b192dabb1f"},
-    {file = "rpds_py-0.19.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:747251e428406b05fc86fee3904ee19550c4d2d19258cef274e2151f31ae9d38"},
-    {file = "rpds_py-0.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dc733d35f861f8d78abfaf54035461e10423422999b360966bf1c443cbc42705"},
-    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbda75f245caecff8faa7e32ee94dfaa8312a3367397975527f29654cd17a6ed"},
-    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd04d8cab16cab5b0a9ffc7d10f0779cf1120ab16c3925404428f74a0a43205a"},
-    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2d66eb41ffca6cc3c91d8387509d27ba73ad28371ef90255c50cb51f8953301"},
-    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fdf4890cda3b59170009d012fca3294c00140e7f2abe1910e6a730809d0f3f9b"},
-    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1fa67ef839bad3815124f5f57e48cd50ff392f4911a9f3cf449d66fa3df62a5"},
-    {file = "rpds_py-0.19.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b82c9514c6d74b89a370c4060bdb80d2299bc6857e462e4a215b4ef7aa7b090e"},
-    {file = "rpds_py-0.19.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c7b07959866a6afb019abb9564d8a55046feb7a84506c74a6f197cbcdf8a208e"},
-    {file = "rpds_py-0.19.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4f580ae79d0b861dfd912494ab9d477bea535bfb4756a2269130b6607a21802e"},
-    {file = "rpds_py-0.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c6d20c8896c00775e6f62d8373aba32956aa0b850d02b5ec493f486c88e12859"},
-    {file = "rpds_py-0.19.1-cp313-none-win32.whl", hash = "sha256:afedc35fe4b9e30ab240b208bb9dc8938cb4afe9187589e8d8d085e1aacb8309"},
-    {file = "rpds_py-0.19.1-cp313-none-win_amd64.whl", hash = "sha256:1d4af2eb520d759f48f1073ad3caef997d1bfd910dc34e41261a595d3f038a94"},
-    {file = "rpds_py-0.19.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:34bca66e2e3eabc8a19e9afe0d3e77789733c702c7c43cd008e953d5d1463fde"},
-    {file = "rpds_py-0.19.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:24f8ae92c7fae7c28d0fae9b52829235df83f34847aa8160a47eb229d9666c7b"},
-    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71157f9db7f6bc6599a852852f3389343bea34315b4e6f109e5cbc97c1fb2963"},
-    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1d494887d40dc4dd0d5a71e9d07324e5c09c4383d93942d391727e7a40ff810b"},
-    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b3661e6d4ba63a094138032c1356d557de5b3ea6fd3cca62a195f623e381c76"},
-    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97fbb77eaeb97591efdc654b8b5f3ccc066406ccfb3175b41382f221ecc216e8"},
-    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4cc4bc73e53af8e7a42c8fd7923bbe35babacfa7394ae9240b3430b5dcf16b2a"},
-    {file = "rpds_py-0.19.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:35af5e4d5448fa179fd7fff0bba0fba51f876cd55212f96c8bbcecc5c684ae5c"},
-    {file = "rpds_py-0.19.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:3511f6baf8438326e351097cecd137eb45c5f019944fe0fd0ae2fea2fd26be39"},
-    {file = "rpds_py-0.19.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:57863d16187995c10fe9cf911b897ed443ac68189179541734502353af33e693"},
-    {file = "rpds_py-0.19.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:9e318e6786b1e750a62f90c6f7fa8b542102bdcf97c7c4de2a48b50b61bd36ec"},
-    {file = "rpds_py-0.19.1-cp38-none-win32.whl", hash = "sha256:53dbc35808c6faa2ce3e48571f8f74ef70802218554884787b86a30947842a14"},
-    {file = "rpds_py-0.19.1-cp38-none-win_amd64.whl", hash = "sha256:8df1c283e57c9cb4d271fdc1875f4a58a143a2d1698eb0d6b7c0d7d5f49c53a1"},
-    {file = "rpds_py-0.19.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:e76c902d229a3aa9d5ceb813e1cbcc69bf5bda44c80d574ff1ac1fa3136dea71"},
-    {file = "rpds_py-0.19.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de1f7cd5b6b351e1afd7568bdab94934d656abe273d66cda0ceea43bbc02a0c2"},
-    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24fc5a84777cb61692d17988989690d6f34f7f95968ac81398d67c0d0994a897"},
-    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:74129d5ffc4cde992d89d345f7f7d6758320e5d44a369d74d83493429dad2de5"},
-    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5e360188b72f8080fefa3adfdcf3618604cc8173651c9754f189fece068d2a45"},
-    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13e6d4840897d4e4e6b2aa1443e3a8eca92b0402182aafc5f4ca1f5e24f9270a"},
-    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f09529d2332264a902688031a83c19de8fda5eb5881e44233286b9c9ec91856d"},
-    {file = "rpds_py-0.19.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0d4b52811dcbc1aba08fd88d475f75b4f6db0984ba12275d9bed1a04b2cae9b5"},
-    {file = "rpds_py-0.19.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dd635c2c4043222d80d80ca1ac4530a633102a9f2ad12252183bcf338c1b9474"},
-    {file = "rpds_py-0.19.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f35b34a5184d5e0cc360b61664c1c06e866aab077b5a7c538a3e20c8fcdbf90b"},
-    {file = "rpds_py-0.19.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d4ec0046facab83012d821b33cead742a35b54575c4edfb7ed7445f63441835f"},
-    {file = "rpds_py-0.19.1-cp39-none-win32.whl", hash = "sha256:f5b8353ea1a4d7dfb59a7f45c04df66ecfd363bb5b35f33b11ea579111d4655f"},
-    {file = "rpds_py-0.19.1-cp39-none-win_amd64.whl", hash = "sha256:1fb93d3486f793d54a094e2bfd9cd97031f63fcb5bc18faeb3dd4b49a1c06523"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7d5c7e32f3ee42f77d8ff1a10384b5cdcc2d37035e2e3320ded909aa192d32c3"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:89cc8921a4a5028d6dd388c399fcd2eef232e7040345af3d5b16c04b91cf3c7e"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bca34e913d27401bda2a6f390d0614049f5a95b3b11cd8eff80fe4ec340a1208"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5953391af1405f968eb5701ebbb577ebc5ced8d0041406f9052638bafe52209d"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:840e18c38098221ea6201f091fc5d4de6128961d2930fbbc96806fb43f69aec1"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d8b735c4d162dc7d86a9cf3d717f14b6c73637a1f9cd57fe7e61002d9cb1972"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce757c7c90d35719b38fa3d4ca55654a76a40716ee299b0865f2de21c146801c"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a9421b23c85f361a133aa7c5e8ec757668f70343f4ed8fdb5a4a14abd5437244"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:3b823be829407393d84ee56dc849dbe3b31b6a326f388e171555b262e8456cc1"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:5e58b61dcbb483a442c6239c3836696b79f2cd8e7eec11e12155d3f6f2d886d1"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:39d67896f7235b2c886fb1ee77b1491b77049dcef6fbf0f401e7b4cbed86bbd4"},
-    {file = "rpds_py-0.19.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8b32cd4ab6db50c875001ba4f5a6b30c0f42151aa1fbf9c2e7e3674893fb1dc4"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1c32e41de995f39b6b315d66c27dea3ef7f7c937c06caab4c6a79a5e09e2c415"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:1a129c02b42d46758c87faeea21a9f574e1c858b9f358b6dd0bbd71d17713175"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:346557f5b1d8fd9966059b7a748fd79ac59f5752cd0e9498d6a40e3ac1c1875f"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:31e450840f2f27699d014cfc8865cc747184286b26d945bcea6042bb6aa4d26e"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01227f8b3e6c8961490d869aa65c99653df80d2f0a7fde8c64ebddab2b9b02fd"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69084fd29bfeff14816666c93a466e85414fe6b7d236cfc108a9c11afa6f7301"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4d2b88efe65544a7d5121b0c3b003ebba92bfede2ea3577ce548b69c5235185"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6ea961a674172ed2235d990d7edf85d15d8dfa23ab8575e48306371c070cda67"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:5beffdbe766cfe4fb04f30644d822a1080b5359df7db3a63d30fa928375b2720"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:720f3108fb1bfa32e51db58b832898372eb5891e8472a8093008010911e324c5"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:c2087dbb76a87ec2c619253e021e4fb20d1a72580feeaa6892b0b3d955175a71"},
-    {file = "rpds_py-0.19.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2ddd50f18ebc05ec29a0d9271e9dbe93997536da3546677f8ca00b76d477680c"},
-    {file = "rpds_py-0.19.1.tar.gz", hash = "sha256:31dd5794837f00b46f4096aa8ccaa5972f73a938982e32ed817bb520c465e520"},
+    {file = "rpds_py-0.20.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3ad0fda1635f8439cde85c700f964b23ed5fc2d28016b32b9ee5fe30da5c84e2"},
+    {file = "rpds_py-0.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9bb4a0d90fdb03437c109a17eade42dfbf6190408f29b2744114d11586611d6f"},
+    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6377e647bbfd0a0b159fe557f2c6c602c159fc752fa316572f012fc0bf67150"},
+    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb851b7df9dda52dc1415ebee12362047ce771fc36914586b2e9fcbd7d293b3e"},
+    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1e0f80b739e5a8f54837be5d5c924483996b603d5502bfff79bf33da06164ee2"},
+    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a8c94dad2e45324fc74dce25e1645d4d14df9a4e54a30fa0ae8bad9a63928e3"},
+    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8e604fe73ba048c06085beaf51147eaec7df856824bfe7b98657cf436623daf"},
+    {file = "rpds_py-0.20.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:df3de6b7726b52966edf29663e57306b23ef775faf0ac01a3e9f4012a24a4140"},
+    {file = "rpds_py-0.20.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf258ede5bc22a45c8e726b29835b9303c285ab46fc7c3a4cc770736b5304c9f"},
+    {file = "rpds_py-0.20.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:55fea87029cded5df854ca7e192ec7bdb7ecd1d9a3f63d5c4eb09148acf4a7ce"},
+    {file = "rpds_py-0.20.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ae94bd0b2f02c28e199e9bc51485d0c5601f58780636185660f86bf80c89af94"},
+    {file = "rpds_py-0.20.0-cp310-none-win32.whl", hash = "sha256:28527c685f237c05445efec62426d285e47a58fb05ba0090a4340b73ecda6dee"},
+    {file = "rpds_py-0.20.0-cp310-none-win_amd64.whl", hash = "sha256:238a2d5b1cad28cdc6ed15faf93a998336eb041c4e440dd7f902528b8891b399"},
+    {file = "rpds_py-0.20.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ac2f4f7a98934c2ed6505aead07b979e6f999389f16b714448fb39bbaa86a489"},
+    {file = "rpds_py-0.20.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:220002c1b846db9afd83371d08d239fdc865e8f8c5795bbaec20916a76db3318"},
+    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d7919548df3f25374a1f5d01fbcd38dacab338ef5f33e044744b5c36729c8db"},
+    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:758406267907b3781beee0f0edfe4a179fbd97c0be2e9b1154d7f0a1279cf8e5"},
+    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3d61339e9f84a3f0767b1995adfb171a0d00a1185192718a17af6e124728e0f5"},
+    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1259c7b3705ac0a0bd38197565a5d603218591d3f6cee6e614e380b6ba61c6f6"},
+    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c1dc0f53856b9cc9a0ccca0a7cc61d3d20a7088201c0937f3f4048c1718a209"},
+    {file = "rpds_py-0.20.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7e60cb630f674a31f0368ed32b2a6b4331b8350d67de53c0359992444b116dd3"},
+    {file = "rpds_py-0.20.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dbe982f38565bb50cb7fb061ebf762c2f254ca3d8c20d4006878766e84266272"},
+    {file = "rpds_py-0.20.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:514b3293b64187172bc77c8fb0cdae26981618021053b30d8371c3a902d4d5ad"},
+    {file = "rpds_py-0.20.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d0a26ffe9d4dd35e4dfdd1e71f46401cff0181c75ac174711ccff0459135fa58"},
+    {file = "rpds_py-0.20.0-cp311-none-win32.whl", hash = "sha256:89c19a494bf3ad08c1da49445cc5d13d8fefc265f48ee7e7556839acdacf69d0"},
+    {file = "rpds_py-0.20.0-cp311-none-win_amd64.whl", hash = "sha256:c638144ce971df84650d3ed0096e2ae7af8e62ecbbb7b201c8935c370df00a2c"},
+    {file = "rpds_py-0.20.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a84ab91cbe7aab97f7446652d0ed37d35b68a465aeef8fc41932a9d7eee2c1a6"},
+    {file = "rpds_py-0.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:56e27147a5a4c2c21633ff8475d185734c0e4befd1c989b5b95a5d0db699b21b"},
+    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2580b0c34583b85efec8c5c5ec9edf2dfe817330cc882ee972ae650e7b5ef739"},
+    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b80d4a7900cf6b66bb9cee5c352b2d708e29e5a37fe9bf784fa97fc11504bf6c"},
+    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:50eccbf054e62a7b2209b28dc7a22d6254860209d6753e6b78cfaeb0075d7bee"},
+    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:49a8063ea4296b3a7e81a5dfb8f7b2d73f0b1c20c2af401fb0cdf22e14711a96"},
+    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea438162a9fcbee3ecf36c23e6c68237479f89f962f82dae83dc15feeceb37e4"},
+    {file = "rpds_py-0.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:18d7585c463087bddcfa74c2ba267339f14f2515158ac4db30b1f9cbdb62c8ef"},
+    {file = "rpds_py-0.20.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d4c7d1a051eeb39f5c9547e82ea27cbcc28338482242e3e0b7768033cb083821"},
+    {file = "rpds_py-0.20.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e4df1e3b3bec320790f699890d41c59d250f6beda159ea3c44c3f5bac1976940"},
+    {file = "rpds_py-0.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2cf126d33a91ee6eedc7f3197b53e87a2acdac63602c0f03a02dd69e4b138174"},
+    {file = "rpds_py-0.20.0-cp312-none-win32.whl", hash = "sha256:8bc7690f7caee50b04a79bf017a8d020c1f48c2a1077ffe172abec59870f1139"},
+    {file = "rpds_py-0.20.0-cp312-none-win_amd64.whl", hash = "sha256:0e13e6952ef264c40587d510ad676a988df19adea20444c2b295e536457bc585"},
+    {file = "rpds_py-0.20.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:aa9a0521aeca7d4941499a73ad7d4f8ffa3d1affc50b9ea11d992cd7eff18a29"},
+    {file = "rpds_py-0.20.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a1f1d51eccb7e6c32ae89243cb352389228ea62f89cd80823ea7dd1b98e0b91"},
+    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a86a9b96070674fc88b6f9f71a97d2c1d3e5165574615d1f9168ecba4cecb24"},
+    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c8ef2ebf76df43f5750b46851ed1cdf8f109d7787ca40035fe19fbdc1acc5a7"},
+    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b74b25f024b421d5859d156750ea9a65651793d51b76a2e9238c05c9d5f203a9"},
+    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57eb94a8c16ab08fef6404301c38318e2c5a32216bf5de453e2714c964c125c8"},
+    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1940dae14e715e2e02dfd5b0f64a52e8374a517a1e531ad9412319dc3ac7879"},
+    {file = "rpds_py-0.20.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d20277fd62e1b992a50c43f13fbe13277a31f8c9f70d59759c88f644d66c619f"},
+    {file = "rpds_py-0.20.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:06db23d43f26478303e954c34c75182356ca9aa7797d22c5345b16871ab9c45c"},
+    {file = "rpds_py-0.20.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b2a5db5397d82fa847e4c624b0c98fe59d2d9b7cf0ce6de09e4d2e80f8f5b3f2"},
+    {file = "rpds_py-0.20.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5a35df9f5548fd79cb2f52d27182108c3e6641a4feb0f39067911bf2adaa3e57"},
+    {file = "rpds_py-0.20.0-cp313-none-win32.whl", hash = "sha256:fd2d84f40633bc475ef2d5490b9c19543fbf18596dcb1b291e3a12ea5d722f7a"},
+    {file = "rpds_py-0.20.0-cp313-none-win_amd64.whl", hash = "sha256:9bc2d153989e3216b0559251b0c260cfd168ec78b1fac33dd485750a228db5a2"},
+    {file = "rpds_py-0.20.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:f2fbf7db2012d4876fb0d66b5b9ba6591197b0f165db8d99371d976546472a24"},
+    {file = "rpds_py-0.20.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1e5f3cd7397c8f86c8cc72d5a791071431c108edd79872cdd96e00abd8497d29"},
+    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce9845054c13696f7af7f2b353e6b4f676dab1b4b215d7fe5e05c6f8bb06f965"},
+    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c3e130fd0ec56cb76eb49ef52faead8ff09d13f4527e9b0c400307ff72b408e1"},
+    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4b16aa0107ecb512b568244ef461f27697164d9a68d8b35090e9b0c1c8b27752"},
+    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aa7f429242aae2947246587d2964fad750b79e8c233a2367f71b554e9447949c"},
+    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af0fc424a5842a11e28956e69395fbbeab2c97c42253169d87e90aac2886d751"},
+    {file = "rpds_py-0.20.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b8c00a3b1e70c1d3891f0db1b05292747f0dbcfb49c43f9244d04c70fbc40eb8"},
+    {file = "rpds_py-0.20.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:40ce74fc86ee4645d0a225498d091d8bc61f39b709ebef8204cb8b5a464d3c0e"},
+    {file = "rpds_py-0.20.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:4fe84294c7019456e56d93e8ababdad5a329cd25975be749c3f5f558abb48253"},
+    {file = "rpds_py-0.20.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:338ca4539aad4ce70a656e5187a3a31c5204f261aef9f6ab50e50bcdffaf050a"},
+    {file = "rpds_py-0.20.0-cp38-none-win32.whl", hash = "sha256:54b43a2b07db18314669092bb2de584524d1ef414588780261e31e85846c26a5"},
+    {file = "rpds_py-0.20.0-cp38-none-win_amd64.whl", hash = "sha256:a1862d2d7ce1674cffa6d186d53ca95c6e17ed2b06b3f4c476173565c862d232"},
+    {file = "rpds_py-0.20.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:3fde368e9140312b6e8b6c09fb9f8c8c2f00999d1823403ae90cc00480221b22"},
+    {file = "rpds_py-0.20.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9824fb430c9cf9af743cf7aaf6707bf14323fb51ee74425c380f4c846ea70789"},
+    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:11ef6ce74616342888b69878d45e9f779b95d4bd48b382a229fe624a409b72c5"},
+    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c52d3f2f82b763a24ef52f5d24358553e8403ce05f893b5347098014f2d9eff2"},
+    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d35cef91e59ebbeaa45214861874bc6f19eb35de96db73e467a8358d701a96c"},
+    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d72278a30111e5b5525c1dd96120d9e958464316f55adb030433ea905866f4de"},
+    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4c29cbbba378759ac5786730d1c3cb4ec6f8ababf5c42a9ce303dc4b3d08cda"},
+    {file = "rpds_py-0.20.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6632f2d04f15d1bd6fe0eedd3b86d9061b836ddca4c03d5cf5c7e9e6b7c14580"},
+    {file = "rpds_py-0.20.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d0b67d87bb45ed1cd020e8fbf2307d449b68abc45402fe1a4ac9e46c3c8b192b"},
+    {file = "rpds_py-0.20.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ec31a99ca63bf3cd7f1a5ac9fe95c5e2d060d3c768a09bc1d16e235840861420"},
+    {file = "rpds_py-0.20.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:22e6c9976e38f4d8c4a63bd8a8edac5307dffd3ee7e6026d97f3cc3a2dc02a0b"},
+    {file = "rpds_py-0.20.0-cp39-none-win32.whl", hash = "sha256:569b3ea770c2717b730b61998b6c54996adee3cef69fc28d444f3e7920313cf7"},
+    {file = "rpds_py-0.20.0-cp39-none-win_amd64.whl", hash = "sha256:e6900ecdd50ce0facf703f7a00df12374b74bbc8ad9fe0f6559947fb20f82364"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:617c7357272c67696fd052811e352ac54ed1d9b49ab370261a80d3b6ce385045"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9426133526f69fcaba6e42146b4e12d6bc6c839b8b555097020e2b78ce908dcc"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:deb62214c42a261cb3eb04d474f7155279c1a8a8c30ac89b7dcb1721d92c3c02"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fcaeb7b57f1a1e071ebd748984359fef83ecb026325b9d4ca847c95bc7311c92"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d454b8749b4bd70dd0a79f428731ee263fa6995f83ccb8bada706e8d1d3ff89d"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d807dc2051abe041b6649681dce568f8e10668e3c1c6543ebae58f2d7e617855"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3c20f0ddeb6e29126d45f89206b8291352b8c5b44384e78a6499d68b52ae511"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b7f19250ceef892adf27f0399b9e5afad019288e9be756d6919cb58892129f51"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:4f1ed4749a08379555cebf4650453f14452eaa9c43d0a95c49db50c18b7da075"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:dcedf0b42bcb4cfff4101d7771a10532415a6106062f005ab97d1d0ab5681c60"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:39ed0d010457a78f54090fafb5d108501b5aa5604cc22408fc1c0c77eac14344"},
+    {file = "rpds_py-0.20.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:bb273176be34a746bdac0b0d7e4e2c467323d13640b736c4c477881a3220a989"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f918a1a130a6dfe1d7fe0f105064141342e7dd1611f2e6a21cd2f5c8cb1cfb3e"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:f60012a73aa396be721558caa3a6fd49b3dd0033d1675c6d59c4502e870fcf0c"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d2b1ad682a3dfda2a4e8ad8572f3100f95fad98cb99faf37ff0ddfe9cbf9d03"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:614fdafe9f5f19c63ea02817fa4861c606a59a604a77c8cdef5aa01d28b97921"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fa518bcd7600c584bf42e6617ee8132869e877db2f76bcdc281ec6a4113a53ab"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f0475242f447cc6cb8a9dd486d68b2ef7fbee84427124c232bff5f63b1fe11e5"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f90a4cd061914a60bd51c68bcb4357086991bd0bb93d8aa66a6da7701370708f"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:def7400461c3a3f26e49078302e1c1b38f6752342c77e3cf72ce91ca69fb1bc1"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:65794e4048ee837494aea3c21a28ad5fc080994dfba5b036cf84de37f7ad5074"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:faefcc78f53a88f3076b7f8be0a8f8d35133a3ecf7f3770895c25f8813460f08"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5b4f105deeffa28bbcdff6c49b34e74903139afa690e35d2d9e3c2c2fba18cec"},
+    {file = "rpds_py-0.20.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:fdfc3a892927458d98f3d55428ae46b921d1f7543b89382fdb483f5640daaec8"},
+    {file = "rpds_py-0.20.0.tar.gz", hash = "sha256:d72a210824facfdaf8768cf2d7ca25a042c30320b3020de2fa04640920d4e121"},
 ]
 
 [[package]]
@@ -2035,36 +2071,44 @@ tests = ["black (>=24.3.0)", "matplotlib (>=3.3.4)", "mypy (>=1.9)", "numpydoc (
 
 [[package]]
 name = "scipy"
-version = "1.14.0"
+version = "1.14.1"
 description = "Fundamental algorithms for scientific computing in Python"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "scipy-1.14.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7e911933d54ead4d557c02402710c2396529540b81dd554fc1ba270eb7308484"},
-    {file = "scipy-1.14.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:687af0a35462402dd851726295c1a5ae5f987bd6e9026f52e9505994e2f84ef6"},
-    {file = "scipy-1.14.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:07e179dc0205a50721022344fb85074f772eadbda1e1b3eecdc483f8033709b7"},
-    {file = "scipy-1.14.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:6a9c9a9b226d9a21e0a208bdb024c3982932e43811b62d202aaf1bb59af264b1"},
-    {file = "scipy-1.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:076c27284c768b84a45dcf2e914d4000aac537da74236a0d45d82c6fa4b7b3c0"},
-    {file = "scipy-1.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42470ea0195336df319741e230626b6225a740fd9dce9642ca13e98f667047c0"},
-    {file = "scipy-1.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:176c6f0d0470a32f1b2efaf40c3d37a24876cebf447498a4cefb947a79c21e9d"},
-    {file = "scipy-1.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:ad36af9626d27a4326c8e884917b7ec321d8a1841cd6dacc67d2a9e90c2f0359"},
-    {file = "scipy-1.14.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6d056a8709ccda6cf36cdd2eac597d13bc03dba38360f418560a93050c76a16e"},
-    {file = "scipy-1.14.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f0a50da861a7ec4573b7c716b2ebdcdf142b66b756a0d392c236ae568b3a93fb"},
-    {file = "scipy-1.14.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:94c164a9e2498e68308e6e148646e486d979f7fcdb8b4cf34b5441894bdb9caf"},
-    {file = "scipy-1.14.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:a7d46c3e0aea5c064e734c3eac5cf9eb1f8c4ceee756262f2c7327c4c2691c86"},
-    {file = "scipy-1.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9eee2989868e274aae26125345584254d97c56194c072ed96cb433f32f692ed8"},
-    {file = "scipy-1.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e3154691b9f7ed73778d746da2df67a19d046a6c8087c8b385bc4cdb2cfca74"},
-    {file = "scipy-1.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c40003d880f39c11c1edbae8144e3813904b10514cd3d3d00c277ae996488cdb"},
-    {file = "scipy-1.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:5b083c8940028bb7e0b4172acafda6df762da1927b9091f9611b0bcd8676f2bc"},
-    {file = "scipy-1.14.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:bff2438ea1330e06e53c424893ec0072640dac00f29c6a43a575cbae4c99b2b9"},
-    {file = "scipy-1.14.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:bbc0471b5f22c11c389075d091d3885693fd3f5e9a54ce051b46308bc787e5d4"},
-    {file = "scipy-1.14.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:64b2ff514a98cf2bb734a9f90d32dc89dc6ad4a4a36a312cd0d6327170339eb0"},
-    {file = "scipy-1.14.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:7d3da42fbbbb860211a811782504f38ae7aaec9de8764a9bef6b262de7a2b50f"},
-    {file = "scipy-1.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d91db2c41dd6c20646af280355d41dfa1ec7eead235642178bd57635a3f82209"},
-    {file = "scipy-1.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a01cc03bcdc777c9da3cfdcc74b5a75caffb48a6c39c8450a9a05f82c4250a14"},
-    {file = "scipy-1.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:65df4da3c12a2bb9ad52b86b4dcf46813e869afb006e58be0f516bc370165159"},
-    {file = "scipy-1.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:4c4161597c75043f7154238ef419c29a64ac4a7c889d588ea77690ac4d0d9b20"},
-    {file = "scipy-1.14.0.tar.gz", hash = "sha256:b5923f48cb840380f9854339176ef21763118a7300a88203ccd0bdd26e58527b"},
+    {file = "scipy-1.14.1-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:b28d2ca4add7ac16ae8bb6632a3c86e4b9e4d52d3e34267f6e1b0c1f8d87e389"},
+    {file = "scipy-1.14.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:d0d2821003174de06b69e58cef2316a6622b60ee613121199cb2852a873f8cf3"},
+    {file = "scipy-1.14.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:8bddf15838ba768bb5f5083c1ea012d64c9a444e16192762bd858f1e126196d0"},
+    {file = "scipy-1.14.1-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:97c5dddd5932bd2a1a31c927ba5e1463a53b87ca96b5c9bdf5dfd6096e27efc3"},
+    {file = "scipy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ff0a7e01e422c15739ecd64432743cf7aae2b03f3084288f399affcefe5222d"},
+    {file = "scipy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e32dced201274bf96899e6491d9ba3e9a5f6b336708656466ad0522d8528f69"},
+    {file = "scipy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8426251ad1e4ad903a4514712d2fa8fdd5382c978010d1c6f5f37ef286a713ad"},
+    {file = "scipy-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:a49f6ed96f83966f576b33a44257d869756df6cf1ef4934f59dd58b25e0327e5"},
+    {file = "scipy-1.14.1-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:2da0469a4ef0ecd3693761acbdc20f2fdeafb69e6819cc081308cc978153c675"},
+    {file = "scipy-1.14.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:c0ee987efa6737242745f347835da2cc5bb9f1b42996a4d97d5c7ff7928cb6f2"},
+    {file = "scipy-1.14.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3a1b111fac6baec1c1d92f27e76511c9e7218f1695d61b59e05e0fe04dc59617"},
+    {file = "scipy-1.14.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8475230e55549ab3f207bff11ebfc91c805dc3463ef62eda3ccf593254524ce8"},
+    {file = "scipy-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:278266012eb69f4a720827bdd2dc54b2271c97d84255b2faaa8f161a158c3b37"},
+    {file = "scipy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fef8c87f8abfb884dac04e97824b61299880c43f4ce675dd2cbeadd3c9b466d2"},
+    {file = "scipy-1.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b05d43735bb2f07d689f56f7b474788a13ed8adc484a85aa65c0fd931cf9ccd2"},
+    {file = "scipy-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:716e389b694c4bb564b4fc0c51bc84d381735e0d39d3f26ec1af2556ec6aad94"},
+    {file = "scipy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:631f07b3734d34aced009aaf6fedfd0eb3498a97e581c3b1e5f14a04164a456d"},
+    {file = "scipy-1.14.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:af29a935803cc707ab2ed7791c44288a682f9c8107bc00f0eccc4f92c08d6e07"},
+    {file = "scipy-1.14.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2843f2d527d9eebec9a43e6b406fb7266f3af25a751aa91d62ff416f54170bc5"},
+    {file = "scipy-1.14.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:eb58ca0abd96911932f688528977858681a59d61a7ce908ffd355957f7025cfc"},
+    {file = "scipy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30ac8812c1d2aab7131a79ba62933a2a76f582d5dbbc695192453dae67ad6310"},
+    {file = "scipy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f9ea80f2e65bdaa0b7627fb00cbeb2daf163caa015e59b7516395fe3bd1e066"},
+    {file = "scipy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:edaf02b82cd7639db00dbff629995ef185c8df4c3ffa71a5562a595765a06ce1"},
+    {file = "scipy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2ff38e22128e6c03ff73b6bb0f85f897d2362f8c052e3b8ad00532198fbdae3f"},
+    {file = "scipy-1.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1729560c906963fc8389f6aac023739ff3983e727b1a4d87696b7bf108316a79"},
+    {file = "scipy-1.14.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:4079b90df244709e675cdc8b93bfd8a395d59af40b72e339c2287c91860deb8e"},
+    {file = "scipy-1.14.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e0cf28db0f24a38b2a0ca33a85a54852586e43cf6fd876365c86e0657cfe7d73"},
+    {file = "scipy-1.14.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:0c2f95de3b04e26f5f3ad5bb05e74ba7f68b837133a4492414b3afd79dfe540e"},
+    {file = "scipy-1.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b99722ea48b7ea25e8e015e8341ae74624f72e5f21fc2abd45f3a93266de4c5d"},
+    {file = "scipy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5149e3fd2d686e42144a093b206aef01932a0059c2a33ddfa67f5f035bdfe13e"},
+    {file = "scipy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e4f5a7c49323533f9103d4dacf4e4f07078f360743dec7f7596949149efeec06"},
+    {file = "scipy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:baff393942b550823bfce952bb62270ee17504d02a1801d7fd0719534dfb9c84"},
+    {file = "scipy-1.14.1.tar.gz", hash = "sha256:5a275584e726026a5699459aa72f828a610821006228e841b94275c4a7c08417"},
 ]
 
 [package.dependencies]
@@ -2072,8 +2116,8 @@ numpy = ">=1.23.5,<2.3"
 
 [package.extras]
 dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy (==1.10.0)", "pycodestyle", "pydevtool", "rich-click", "ruff (>=0.0.292)", "types-psutil", "typing_extensions"]
-doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.13.1)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0)", "sphinx-design (>=0.4.0)"]
-test = ["Cython", "array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.13.1)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0,<=7.3.7)", "sphinx-design (>=0.4.0)"]
+test = ["Cython", "array-api-strict (>=2.0)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
 name = "six"
@@ -2117,13 +2161,13 @@ ujson = ["ujson (>=5.5.0)"]
 
 [[package]]
 name = "sympy"
-version = "1.13.1"
+version = "1.13.2"
 description = "Computer algebra system (CAS) in Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "sympy-1.13.1-py3-none-any.whl", hash = "sha256:db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8"},
-    {file = "sympy-1.13.1.tar.gz", hash = "sha256:9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f"},
+    {file = "sympy-1.13.2-py3-none-any.whl", hash = "sha256:c51d75517712f1aed280d4ce58506a4a88d635d6b5dd48b39102a7ae1f3fcfe9"},
+    {file = "sympy-1.13.2.tar.gz", hash = "sha256:401449d84d07be9d0c7a46a64bd54fe097667d5e7181bfe67ec777be9e01cb13"},
 ]
 
 [package.dependencies]
@@ -2134,15 +2178,15 @@ dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
 
 [[package]]
 name = "tbb"
-version = "2021.13.0"
+version = "2021.13.1"
 description = "Intel® oneAPI Threading Building Blocks (oneTBB)"
 optional = false
 python-versions = "*"
 files = [
-    {file = "tbb-2021.13.0-py2.py3-none-manylinux1_i686.whl", hash = "sha256:a2567725329639519d46d92a2634cf61e76601dac2f777a05686fea546c4fe4f"},
-    {file = "tbb-2021.13.0-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:aaf667e92849adb012b8874d6393282afc318aca4407fc62f912ee30a22da46a"},
-    {file = "tbb-2021.13.0-py3-none-win32.whl", hash = "sha256:6669d26703e9943f6164c6407bd4a237a45007e79b8d3832fe6999576eaaa9ef"},
-    {file = "tbb-2021.13.0-py3-none-win_amd64.whl", hash = "sha256:3528a53e4bbe64b07a6112b4c5a00ff3c61924ee46c9c68e004a1ac7ad1f09c3"},
+    {file = "tbb-2021.13.1-py2.py3-none-manylinux1_i686.whl", hash = "sha256:bb5bdea0c0e9e6ad0739e7a8796c2635ce9eccca86dd48c426cd8027ac70fb1d"},
+    {file = "tbb-2021.13.1-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:d916359dc685579d09e4b344241550afc1cc034f7f5ec7234c258b6680912d70"},
+    {file = "tbb-2021.13.1-py3-none-win32.whl", hash = "sha256:00f5e5a70051650ddd0ab6247c0549521968339ec21002e475cd23b1cbf46d66"},
+    {file = "tbb-2021.13.1-py3-none-win_amd64.whl", hash = "sha256:cbf024b2463fdab3ebe3fa6ff453026358e6b903839c80d647e08ad6d0796ee9"},
 ]
 
 [[package]]
@@ -2169,13 +2213,13 @@ files = [
 
 [[package]]
 name = "tomlkit"
-version = "0.13.0"
+version = "0.13.2"
 description = "Style preserving TOML library"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tomlkit-0.13.0-py3-none-any.whl", hash = "sha256:7075d3042d03b80f603482d69bf0c8f345c2b30e41699fd8883227f89972b264"},
-    {file = "tomlkit-0.13.0.tar.gz", hash = "sha256:08ad192699734149f5b97b45f1f18dad7eb1b6d16bc72ad0c2335772650d7b72"},
+    {file = "tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde"},
+    {file = "tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"},
 ]
 
 [[package]]
@@ -2271,13 +2315,13 @@ scipy = ["scipy"]
 
 [[package]]
 name = "tqdm"
-version = "4.66.4"
+version = "4.66.5"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tqdm-4.66.4-py3-none-any.whl", hash = "sha256:b75ca56b413b030bc3f00af51fd2c1a1a5eac6a0c1cca83cbb37a5c52abce644"},
-    {file = "tqdm-4.66.4.tar.gz", hash = "sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb"},
+    {file = "tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd"},
+    {file = "tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad"},
 ]
 
 [package.dependencies]
@@ -2358,4 +2402,4 @@ linter = ["black", "isort"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a4d7307ef46e24e0e1206414f853939dbef441ea22d2a72528a0821b0ac85956"
+content-hash = "e6ee12b7e685deb23469eb869a6e8d0268720059ab4523f9b4e39bbbef8ba62e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ isort = {version="^5.13.2", optional=true}
 pytest = "^8.2.0"
 pandas = "^2.2.2"
 pylint = "^3.2.3"
-mypy = "^1.10.0"
+mypy = "^1.11.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nada-ai"
-version = "0.4.0"
+version = "0.5.0"
 description = "Nada-AI is a Python library designed for AI/ML on top of Nada DSL and Nillion Network."
 authors = ["Mathias Leys <mathias.leys@nillion.com>"]
 readme = "README.md"
@@ -11,9 +11,9 @@ torch = "^2.0.0"
 scikit-learn = "^1.4.2"
 prophet = "^1.1.5"
 nillion-python-helpers = "^0.2.3"
-nada-numpy="^0.4.0"
-nada-dsl="^0.5.0"
-py-nillion-client="^0.5.0"
+nada-numpy="^0.5.0"
+nada-dsl="^0.6.0"
+py-nillion-client="^0.6.0"
 torchvision = {version="^0.18.1", optional=true}
 black = {version="^24.4.2", optional=true}
 isort = {version="^5.13.2", optional=true}

--- a/tests/nada-tests/src/flatten.py
+++ b/tests/nada-tests/src/flatten.py
@@ -13,6 +13,8 @@ def nada_main():
 
     x_flat = flatten(x)
 
+    x_flat += Integer(0)
+
     assert x_flat.shape == (8,), x_flat.shape
 
     assert Flatten()(x).shape == (2, 4), Flatten(start_dim=0)(x).shape

--- a/tests/nada-tests/src/load_state.py
+++ b/tests/nada-tests/src/load_state.py
@@ -8,6 +8,7 @@ from nada_ai.nn import Module, Parameter
 def nada_main():
     party = Party("party")
 
+
     class TestModule(Module):
         def __init__(self) -> None:
             self.param1 = Parameter(na.zeros((3, 2), na.Rational))
@@ -24,7 +25,8 @@ def nada_main():
         mod2.load_state_from_network("module2", party, nada_type=SecretInteger)
 
     mod2.load_state_from_network("module2", party, nada_type=na.Rational)
-
+    mod1.param1 += na.rational(0)
+    
     m1_p1_out = mod1.param1.output(party, "module1_param1")
     m1_p2_out = mod1.param2.output(party, "module1_param2")
 

--- a/tests/nada-tests/tests/activations.yaml
+++ b/tests/nada-tests/tests/activations.yaml
@@ -1,35 +1,19 @@
 program: activations
 inputs:
-  input_x_0:
-    SecretInteger: '-2'
-  input_x_1:
-    SecretInteger: '0'
-  input_x_2:
-    SecretInteger: '4'
-  input_x_3:
-    SecretInteger: '-121'
-  input_y_0:
-    SecretInteger: '-131072'
-  input_y_1:
-    SecretInteger: '0'
-  input_y_2:
-    SecretInteger: '262144'
-  input_y_3:
-    SecretInteger: '-7929856'
+  input_x_0: -2
+  input_x_1: 0
+  input_x_2: 4
+  input_x_3: -121
+  input_y_0: -131072
+  input_y_1: 0
+  input_y_2: 262144
+  input_y_3: -7929856
 expected_outputs:
-  relu_x_0:
-    SecretInteger: '0'
-  relu_x_1:
-    SecretInteger: '0'
-  relu_x_2:
-    SecretInteger: '4'
-  relu_x_3:
-    SecretInteger: '0'
-  relu_y_0:
-    SecretInteger: '0'
-  relu_y_1:
-    SecretInteger: '0'
-  relu_y_2:
-    SecretInteger: '262144'
-  relu_y_3:
-    SecretInteger: '0'
+  relu_x_0: 0
+  relu_x_1: 0
+  relu_x_2: 4
+  relu_x_3: 0
+  relu_y_0: 0
+  relu_y_1: 0
+  relu_y_2: 262144
+  relu_y_3: 0

--- a/tests/nada-tests/tests/conv.yaml
+++ b/tests/nada-tests/tests/conv.yaml
@@ -1,189 +1,106 @@
+---
 program: conv
 inputs:
-  input_x_0_0_2_1:
-    SecretInteger: '3'
-  conv2_weight_1_2_0_1:
-    SecretInteger: '3'
-  input_x_0_0_2_0:
-    SecretInteger: '3'
-  conv1_weight_0_0_1_1:
-    SecretInteger: '3'
-  conv2_weight_1_0_1_0:
-    SecretInteger: '3'
-  conv2_weight_1_1_0_1:
-    SecretInteger: '3'
-  input_y_1_0_0:
-    SecretInteger: '3'
-  input_y_0_2_1:
-    SecretInteger: '3'
-  input_y_0_3_0:
-    SecretInteger: '3'
-  input_x_0_1_1_0:
-    SecretInteger: '3'
-  input_y_0_3_1:
-    SecretInteger: '3'
-  conv1_weight_0_1_0_0:
-    SecretInteger: '3'
-  conv1_weight_0_2_0_0:
-    SecretInteger: '3'
-  input_y_1_2_0:
-    SecretInteger: '3'
-  input_y_0_1_1:
-    SecretInteger: '3'
-  input_x_0_1_2_1:
-    SecretInteger: '3'
-  input_y_2_0_1:
-    SecretInteger: '3'
-  input_x_0_0_1_0:
-    SecretInteger: '3'
-  conv1_weight_0_1_1_0:
-    SecretInteger: '3'
-  input_x_0_2_1_1:
-    SecretInteger: '3'
-  conv2_weight_0_1_0_1:
-    SecretInteger: '3'
-  input_y_1_0_1:
-    SecretInteger: '3'
-  input_y_2_1_0:
-    SecretInteger: '3'
-  input_y_1_1_1:
-    SecretInteger: '3'
-  input_x_0_1_2_0:
-    SecretInteger: '3'
-  input_x_0_0_1_1:
-    SecretInteger: '3'
-  conv1_weight_0_0_1_0:
-    SecretInteger: '3'
-  input_x_0_0_3_0:
-    SecretInteger: '3'
-  input_x_0_1_3_1:
-    SecretInteger: '3'
-  input_y_2_1_1:
-    SecretInteger: '3'
-  conv2_bias_1:
-    SecretInteger: '3'
-  input_y_1_3_1:
-    SecretInteger: '3'
-  conv2_weight_0_0_0_0:
-    SecretInteger: '3'
-  input_x_0_2_3_0:
-    SecretInteger: '3'
-  input_x_0_1_3_0:
-    SecretInteger: '3'
-  conv2_weight_0_1_1_0:
-    SecretInteger: '3'
-  conv2_weight_1_1_1_1:
-    SecretInteger: '3'
-  input_y_1_2_1:
-    SecretInteger: '3'
-  input_x_0_0_0_1:
-    SecretInteger: '3'
-  input_x_0_2_3_1:
-    SecretInteger: '3'
-  input_y_2_3_1:
-    SecretInteger: '3'
-  input_x_0_0_3_1:
-    SecretInteger: '3'
-  input_y_0_2_0:
-    SecretInteger: '3'
-  conv2_weight_0_0_0_1:
-    SecretInteger: '3'
-  conv1_weight_0_0_0_1:
-    SecretInteger: '3'
-  conv2_weight_1_2_0_0:
-    SecretInteger: '3'
-  input_x_0_2_1_0:
-    SecretInteger: '3'
-  conv1_weight_0_2_1_0:
-    SecretInteger: '3'
-  conv2_weight_0_2_0_0:
-    SecretInteger: '3'
-  input_y_1_1_0:
-    SecretInteger: '3'
-  input_y_0_0_1:
-    SecretInteger: '3'
-  input_x_0_1_0_1:
-    SecretInteger: '3'
-  conv2_weight_1_0_0_0:
-    SecretInteger: '3'
-  conv1_weight_0_1_1_1:
-    SecretInteger: '3'
-  input_x_0_2_0_0:
-    SecretInteger: '3'
-  conv1_weight_0_2_1_1:
-    SecretInteger: '3'
-  conv2_weight_0_1_0_0:
-    SecretInteger: '3'
-  input_y_2_0_0:
-    SecretInteger: '3'
-  input_y_2_2_0:
-    SecretInteger: '3'
-  input_y_1_3_0:
-    SecretInteger: '3'
-  conv2_weight_0_0_1_0:
-    SecretInteger: '3'
-  conv1_weight_0_0_0_0:
-    SecretInteger: '3'
-  input_x_0_1_0_0:
-    SecretInteger: '3'
-  input_x_0_2_2_0:
-    SecretInteger: '3'
-  conv2_bias_0:
-    SecretInteger: '3'
-  conv2_weight_0_2_0_1:
-    SecretInteger: '3'
-  input_x_0_0_0_0:
-    SecretInteger: '3'
-  conv2_weight_1_2_1_1:
-    SecretInteger: '3'
-  input_y_2_3_0:
-    SecretInteger: '3'
-  conv2_weight_0_2_1_0:
-    SecretInteger: '3'
-  conv2_weight_1_2_1_0:
-    SecretInteger: '3'
-  input_y_2_2_1:
-    SecretInteger: '3'
-  conv1_weight_0_2_0_1:
-    SecretInteger: '3'
-  input_y_0_0_0:
-    SecretInteger: '3'
-  conv2_weight_0_0_1_1:
-    SecretInteger: '3'
-  input_y_0_1_0:
-    SecretInteger: '3'
-  input_x_0_1_1_1:
-    SecretInteger: '3'
-  input_x_0_2_0_1:
-    SecretInteger: '3'
-  conv1_weight_0_1_0_1:
-    SecretInteger: '3'
-  conv2_weight_0_2_1_1:
-    SecretInteger: '3'
-  conv1_bias_0:
-    SecretInteger: '3'
-  input_x_0_2_2_1:
-    SecretInteger: '3'
-  conv2_weight_1_0_1_1:
-    SecretInteger: '3'
-  conv2_weight_0_1_1_1:
-    SecretInteger: '3'
-  conv2_weight_1_1_1_0:
-    SecretInteger: '3'
-  conv2_weight_1_1_0_0:
-    SecretInteger: '3'
-  conv2_weight_1_0_0_1:
-    SecretInteger: '3'
+  conv1_bias_0: 3
+  conv1_weight_0_0_0_0: 3
+  conv1_weight_0_0_0_1: 3
+  conv1_weight_0_0_1_0: 3
+  conv1_weight_0_0_1_1: 3
+  conv1_weight_0_1_0_0: 3
+  conv1_weight_0_1_0_1: 3
+  conv1_weight_0_1_1_0: 3
+  conv1_weight_0_1_1_1: 3
+  conv1_weight_0_2_0_0: 3
+  conv1_weight_0_2_0_1: 3
+  conv1_weight_0_2_1_0: 3
+  conv1_weight_0_2_1_1: 3
+  conv2_bias_0: 3
+  conv2_bias_1: 3
+  conv2_weight_0_0_0_0: 3
+  conv2_weight_0_0_0_1: 3
+  conv2_weight_0_0_1_0: 3
+  conv2_weight_0_0_1_1: 3
+  conv2_weight_0_1_0_0: 3
+  conv2_weight_0_1_0_1: 3
+  conv2_weight_0_1_1_0: 3
+  conv2_weight_0_1_1_1: 3
+  conv2_weight_0_2_0_0: 3
+  conv2_weight_0_2_0_1: 3
+  conv2_weight_0_2_1_0: 3
+  conv2_weight_0_2_1_1: 3
+  conv2_weight_1_0_0_0: 3
+  conv2_weight_1_0_0_1: 3
+  conv2_weight_1_0_1_0: 3
+  conv2_weight_1_0_1_1: 3
+  conv2_weight_1_1_0_0: 3
+  conv2_weight_1_1_0_1: 3
+  conv2_weight_1_1_1_0: 3
+  conv2_weight_1_1_1_1: 3
+  conv2_weight_1_2_0_0: 3
+  conv2_weight_1_2_0_1: 3
+  conv2_weight_1_2_1_0: 3
+  conv2_weight_1_2_1_1: 3
+  input_x_0_0_0_0: 3
+  input_x_0_0_0_1: 3
+  input_x_0_0_1_0: 3
+  input_x_0_0_1_1: 3
+  input_x_0_0_2_0: 3
+  input_x_0_0_2_1: 3
+  input_x_0_0_3_0: 3
+  input_x_0_0_3_1: 3
+  input_x_0_1_0_0: 3
+  input_x_0_1_0_1: 3
+  input_x_0_1_1_0: 3
+  input_x_0_1_1_1: 3
+  input_x_0_1_2_0: 3
+  input_x_0_1_2_1: 3
+  input_x_0_1_3_0: 3
+  input_x_0_1_3_1: 3
+  input_x_0_2_0_0: 3
+  input_x_0_2_0_1: 3
+  input_x_0_2_1_0: 3
+  input_x_0_2_1_1: 3
+  input_x_0_2_2_0: 3
+  input_x_0_2_2_1: 3
+  input_x_0_2_3_0: 3
+  input_x_0_2_3_1: 3
+  input_y_0_0_0: 3
+  input_y_0_0_1: 3
+  input_y_0_1_0: 3
+  input_y_0_1_1: 3
+  input_y_0_2_0: 3
+  input_y_0_2_1: 3
+  input_y_0_3_0: 3
+  input_y_0_3_1: 3
+  input_y_1_0_0: 3
+  input_y_1_0_1: 3
+  input_y_1_1_0: 3
+  input_y_1_1_1: 3
+  input_y_1_2_0: 3
+  input_y_1_2_1: 3
+  input_y_1_3_0: 3
+  input_y_1_3_1: 3
+  input_y_2_0_0: 3
+  input_y_2_0_1: 3
+  input_y_2_1_0: 3
+  input_y_2_1_1: 3
+  input_y_2_2_0: 3
+  input_y_2_2_1: 3
+  input_y_2_3_0: 3
+  input_y_2_3_1: 3
 expected_outputs:
-  x_conv_0_0_2_0:
-    SecretInteger: '3'
-  y_conv_0_1_0:
-    SecretInteger: '57'
-  y_conv_0_2_0:
-    SecretInteger: '30'
-  x_conv_0_0_0_0:
-    SecretInteger: '3'
-  x_conv_0_0_1_0:
-    SecretInteger: '3'
-  y_conv_0_0_0:
-    SecretInteger: '30'
+  x_conv_0_0_0_0: 3
+  x_conv_0_0_1_0: 3
+  x_conv_0_0_2_0: 3
+  y_conv_0_0_0: 30
+  y_conv_0_0_1: 30
+  y_conv_0_1_0: 57
+  y_conv_0_1_1: 57
+  y_conv_0_2_0: 30
+  y_conv_0_2_1: 30
+  y_conv_1_0_0: 30
+  y_conv_1_0_1: 30
+  y_conv_1_1_0: 57
+  y_conv_1_1_1: 57
+  y_conv_1_2_0: 30
+  y_conv_1_2_1: 30

--- a/tests/nada-tests/tests/distance.yaml
+++ b/tests/nada-tests/tests/distance.yaml
@@ -1,65 +1,34 @@
 program: distance
 inputs:
-  input_x_0_0:
-    SecretInteger: '1'
-  input_x_0_1:
-    SecretInteger: '2'
-  input_x_0_2:
-    SecretInteger: '3'
-  input_x_1_0:
-    SecretInteger: '4'
-  input_x_1_1:
-    SecretInteger: '5'
-  input_x_1_2:
-    SecretInteger: '6'
-  input_y_0_0:
-    SecretInteger: '1'
-  input_y_0_1:
-    SecretInteger: '2'
-  input_y_0_2:
-    SecretInteger: '3'
-  input_y_1_0:
-    SecretInteger: '4'
-  input_y_1_1:
-    SecretInteger: '5'
-  input_y_1_2:
-    SecretInteger: '6'
-  input_y_2_0:
-    SecretInteger: '7'
-  input_y_2_1:
-    SecretInteger: '8'
-  input_y_2_2:
-    SecretInteger: '9'
-  input_y_3_0:
-    SecretInteger: '10'
-  input_y_3_1:
-    SecretInteger: '11'
-  input_y_3_2:
-    SecretInteger: '12'
-  input_y_4_0:
-    SecretInteger: '13'
-  input_y_4_1:
-    SecretInteger: '14'
-  input_y_4_2:
-    SecretInteger: '15'
+  input_x_0_0: 1
+  input_x_0_1: 2
+  input_x_0_2: 3
+  input_x_1_0: 4
+  input_x_1_1: 5
+  input_x_1_2: 6
+  input_y_0_0: 1
+  input_y_0_1: 2
+  input_y_0_2: 3
+  input_y_1_0: 4
+  input_y_1_1: 5
+  input_y_1_2: 6
+  input_y_2_0: 7
+  input_y_2_1: 8
+  input_y_2_2: 9
+  input_y_3_0: 10
+  input_y_3_1: 11
+  input_y_3_2: 12
+  input_y_4_0: 13
+  input_y_4_1: 14
+  input_y_4_2: 15
 expected_outputs:
-  my_output_0_0:
-    SecretInteger: '14'
-  my_output_0_1:
-    SecretInteger: '32'
-  my_output_0_2:
-    SecretInteger: '50'
-  my_output_0_3:
-    SecretInteger: '68'
-  my_output_0_4:
-    SecretInteger: '86'
-  my_output_1_0:
-    SecretInteger: '32'
-  my_output_1_1:
-    SecretInteger: '77'
-  my_output_1_2:
-    SecretInteger: '122'
-  my_output_1_3:
-    SecretInteger: '167'
-  my_output_1_4:
-    SecretInteger: '212'
+  my_output_0_0: 14
+  my_output_0_1: 32
+  my_output_0_2: 50
+  my_output_0_3: 68
+  my_output_0_4: 86
+  my_output_1_0: 32
+  my_output_1_1: 77
+  my_output_1_2: 122
+  my_output_1_3: 167
+  my_output_1_4: 212

--- a/tests/nada-tests/tests/end-to-end.yaml
+++ b/tests/nada-tests/tests/end-to-end.yaml
@@ -1,125 +1,64 @@
 program: end-to-end
 inputs:
-  input_x_0_0_2_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_2_0_1:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_2_0_0:
-    SecretInteger: '3'
-  testmod_linear.weight_1_0:
-    SecretInteger: '3'
-  input_x_0_0_1_0:
-    SecretInteger: '3'
-  testmod_linear.weight_0_1:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_0_0_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_1_0_1:
-    SecretInteger: '3'
-  input_x_0_1_1_1:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_1_1_0:
-    SecretInteger: '3'
-  input_x_0_2_0_0:
-    SecretInteger: '3'
-  input_x_0_0_0_2:
-    SecretInteger: '3'
-  input_x_0_0_2_2:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_0_1_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_0_1_1:
-    SecretInteger: '3'
-  testmod_conv_module.conv.bias_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_2_1_0:
-    SecretInteger: '3'
-  input_x_0_1_0_2:
-    SecretInteger: '3'
-  testmod_linear.weight_0_0:
-    SecretInteger: '3'
-  input_x_0_2_2_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_0_1_1:
-    SecretInteger: '3'
-  input_x_0_2_2_2:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_2_1_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.bias_1:
-    SecretInteger: '3'
-  input_x_0_1_1_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_0_0_1:
-    SecretInteger: '3'
-  input_x_0_0_1_2:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_0_0_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_1_0_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_2_0_0:
-    SecretInteger: '3'
-  input_x_0_2_2_1:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_1_0_1:
-    SecretInteger: '3'
-  input_x_0_1_0_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_0_0_1:
-    SecretInteger: '3'
-  input_x_0_0_0_0:
-    SecretInteger: '3'
-  testmod_linear.weight_1_1:
-    SecretInteger: '3'
-  input_x_0_1_1_2:
-    SecretInteger: '3'
-  input_x_0_0_0_1:
-    SecretInteger: '3'
-  testmod_linear.bias_0:
-    SecretInteger: '3'
-  input_x_0_2_0_1:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_1_1_0:
-    SecretInteger: '3'
-  input_x_0_2_0_2:
-    SecretInteger: '3'
-  input_x_0_1_2_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_1_0_0:
-    SecretInteger: '3'
-  input_x_0_0_1_1:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_2_0_1:
-    SecretInteger: '3'
-  input_x_0_2_1_1:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_2_1_1:
-    SecretInteger: '3'
-  input_x_0_2_1_2:
-    SecretInteger: '3'
-  input_x_0_1_2_2:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_1_1_1:
-    SecretInteger: '3'
-  testmod_linear.bias_1:
-    SecretInteger: '3'
-  input_x_0_1_0_1:
-    SecretInteger: '3'
-  input_x_0_2_1_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_1_2_1_1:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_0_1_0:
-    SecretInteger: '3'
-  testmod_conv_module.conv.weight_0_1_1_1:
-    SecretInteger: '3'
-  input_x_0_0_2_1:
-    SecretInteger: '3'
-  input_x_0_1_2_1:
-    SecretInteger: '3'
+  input_x_0_0_2_0: 3
+  testmod_conv_module.conv.weight_1_2_0_1: 3
+  testmod_conv_module.conv.weight_0_2_0_0: 3
+  testmod_linear.weight_1_0: 3
+  input_x_0_0_1_0: 3
+  testmod_linear.weight_0_1: 3
+  testmod_conv_module.conv.weight_0_0_0_0: 3
+  testmod_conv_module.conv.weight_1_1_0_1: 3
+  input_x_0_1_1_1: 3
+  testmod_conv_module.conv.weight_0_1_1_0: 3
+  input_x_0_2_0_0: 3
+  input_x_0_0_0_2: 3
+  input_x_0_0_2_2: 3
+  testmod_conv_module.conv.weight_1_0_1_0: 3
+  testmod_conv_module.conv.weight_1_0_1_1: 3
+  testmod_conv_module.conv.bias_0: 3
+  testmod_conv_module.conv.weight_1_2_1_0: 3
+  input_x_0_1_0_2: 3
+  testmod_linear.weight_0_0: 3
+  input_x_0_2_2_0: 3
+  testmod_conv_module.conv.weight_0_0_1_1: 3
+  input_x_0_2_2_2: 3
+  testmod_conv_module.conv.weight_0_2_1_0: 3
+  testmod_conv_module.conv.bias_1: 3
+  input_x_0_1_1_0: 3
+  testmod_conv_module.conv.weight_1_0_0_1: 3
+  input_x_0_0_1_2: 3
+  testmod_conv_module.conv.weight_1_0_0_0: 3
+  testmod_conv_module.conv.weight_0_1_0_0: 3
+  testmod_conv_module.conv.weight_1_2_0_0: 3
+  input_x_0_2_2_1: 3
+  testmod_conv_module.conv.weight_0_1_0_1: 3
+  input_x_0_1_0_0: 3
+  testmod_conv_module.conv.weight_0_0_0_1: 3
+  input_x_0_0_0_0: 3
+  testmod_linear.weight_1_1: 3
+  input_x_0_1_1_2: 3
+  input_x_0_0_0_1: 3
+  testmod_linear.bias_0: 3
+  input_x_0_2_0_1: 3
+  testmod_conv_module.conv.weight_1_1_1_0: 3
+  input_x_0_2_0_2: 3
+  input_x_0_1_2_0: 3
+  testmod_conv_module.conv.weight_1_1_0_0: 3
+  input_x_0_0_1_1: 3
+  testmod_conv_module.conv.weight_0_2_0_1: 3
+  input_x_0_2_1_1: 3
+  testmod_conv_module.conv.weight_0_2_1_1: 3
+  input_x_0_2_1_2: 3
+  input_x_0_1_2_2: 3
+  testmod_conv_module.conv.weight_1_1_1_1: 3
+  testmod_linear.bias_1: 3
+  input_x_0_1_0_1: 3
+  input_x_0_2_1_0: 3
+  testmod_conv_module.conv.weight_1_2_1_1: 3
+  testmod_conv_module.conv.weight_0_0_1_0: 3
+  testmod_conv_module.conv.weight_0_1_1_1: 3
+  input_x_0_0_2_1: 3
+  input_x_0_1_2_1: 3
 expected_outputs:
-  output_0:
-    SecretInteger: '669'
-  output_1:
-    SecretInteger: '669'
+  output_0: 669
+  output_1: 669

--- a/tests/nada-tests/tests/flatten.yaml
+++ b/tests/nada-tests/tests/flatten.yaml
@@ -1,35 +1,19 @@
 program: flatten
 inputs:
-  input_x_0_0_0_0:
-    SecretInteger: '1'
-  input_x_0_0_1_0:
-    SecretInteger: '2'
-  input_x_0_1_0_0:
-    SecretInteger: '3'
-  input_x_0_1_1_0:
-    SecretInteger: '4'
-  input_x_1_0_0_0:
-    SecretInteger: '5'
-  input_x_1_0_1_0:
-    SecretInteger: '6'
-  input_x_1_1_0_0:
-    SecretInteger: '7'
-  input_x_1_1_1_0:
-    SecretInteger: '8'
+  input_x_0_0_0_0: 1
+  input_x_0_0_1_0: 2
+  input_x_0_1_0_0: 3
+  input_x_0_1_1_0: 4
+  input_x_1_0_0_0: 5
+  input_x_1_0_1_0: 6
+  input_x_1_1_0_0: 7
+  input_x_1_1_1_0: 8
 expected_outputs:
-  x_flat_0:
-    SecretInteger: '1'
-  x_flat_1:
-    SecretInteger: '2'
-  x_flat_2:
-    SecretInteger: '3'
-  x_flat_3:
-    SecretInteger: '4'
-  x_flat_4:
-    SecretInteger: '5'
-  x_flat_5:
-    SecretInteger: '6'
-  x_flat_6:
-    SecretInteger: '7'
-  x_flat_7:
-    SecretInteger: '8'
+  x_flat_0: 1
+  x_flat_1: 2
+  x_flat_2: 3
+  x_flat_3: 4
+  x_flat_4: 5
+  x_flat_5: 6
+  x_flat_6: 7
+  x_flat_7: 8

--- a/tests/nada-tests/tests/linear_layers.yaml
+++ b/tests/nada-tests/tests/linear_layers.yaml
@@ -1,33 +1,18 @@
 program: linear_layers
 inputs:
-  input_0:
-    SecretInteger: '1'
-  input_1:
-    SecretInteger: '2'
-  input_2:
-    SecretInteger: '3'
-  testmod_linear_0.weight_0_0:
-    SecretInteger: '1'
-  testmod_linear_0.weight_0_1:
-    SecretInteger: '2'
-  testmod_linear_0.weight_0_2:
-    SecretInteger: '3'
-  testmod_linear_0.weight_1_0:
-    SecretInteger: '4'
-  testmod_linear_0.weight_1_1:
-    SecretInteger: '5'
-  testmod_linear_0.weight_1_2:
-    SecretInteger: '6'
-  testmod_linear_0.bias_0:
-    SecretInteger: '4'
-  testmod_linear_0.bias_1:
-    SecretInteger: '5'
-  testmod_linear_1.weight_0_0:
-    SecretInteger: '3'
-  testmod_linear_1.weight_0_1:
-    SecretInteger: '4'
-  testmod_linear_1.bias_0:
-    SecretInteger: '5'
+  input_0: 1
+  input_1: 2
+  input_2: 3
+  testmod_linear_0.weight_0_0: 1
+  testmod_linear_0.weight_0_1: 2
+  testmod_linear_0.weight_0_2: 3
+  testmod_linear_0.weight_1_0: 4
+  testmod_linear_0.weight_1_1: 5
+  testmod_linear_0.weight_1_2: 6
+  testmod_linear_0.bias_0: 4
+  testmod_linear_0.bias_1: 5
+  testmod_linear_1.weight_0_0: 3
+  testmod_linear_1.weight_0_1: 4
+  testmod_linear_1.bias_0: 5
 expected_outputs:
-  output_0:
-    SecretInteger: '207'
+  output_0: 207

--- a/tests/nada-tests/tests/linear_regression.yaml
+++ b/tests/nada-tests/tests/linear_regression.yaml
@@ -1,23 +1,13 @@
 program: linear_regression
 inputs:
-  input_0:
-    SecretInteger: '1'
-  input_1:
-    SecretInteger: '2'
-  input_2:
-    SecretInteger: '3'
-  input_3:
-    SecretInteger: '3'
-  testmod_coef_0:
-    SecretInteger: '4'
-  testmod_coef_1:
-    SecretInteger: '3'
-  testmod_coef_2:
-    SecretInteger: '2'
-  testmod_coef_3:
-    SecretInteger: '1'
-  testmod_intercept_0:
-    SecretInteger: '3'
+  input_0: 1
+  input_1: 2
+  input_2: 3
+  input_3: 3
+  testmod_coef_0: 4
+  testmod_coef_1: 3
+  testmod_coef_2: 2
+  testmod_coef_3: 1
+  testmod_intercept_0: 3
 expected_outputs:
-  my_output:
-    SecretInteger: '22'
+  my_output: 22

--- a/tests/nada-tests/tests/load_state.yaml
+++ b/tests/nada-tests/tests/load_state.yaml
@@ -1,67 +1,35 @@
 program: load_state
 inputs:
-  module1_param1_0_0:
-    SecretInteger: '1'
-  module1_param1_0_1:
-    SecretInteger: '2'
-  module1_param1_1_0:
-    SecretInteger: '3'
-  module1_param1_1_1:
-    SecretInteger: '4'
-  module1_param1_2_0:
-    SecretInteger: '5'
-  module1_param1_2_1:
-    SecretInteger: '6'
-  module1_param2_0:
-    SecretInteger: '7'
-  module1_param2_1:
-    SecretInteger: '8'
-  module2_param1_0_0:
-    Integer: '1'
-  module2_param1_0_1:
-    Integer: '2'
-  module2_param1_1_0:
-    Integer: '3'
-  module2_param1_1_1:
-    Integer: '4'
-  module2_param1_2_0:
-    Integer: '5'
-  module2_param1_2_1:
-    Integer: '6'
-  module2_param2_0:
-    Integer: '7'
-  module2_param2_1:
-    Integer: '8'
+  module1_param1_0_0: 1
+  module1_param1_0_1: 2
+  module1_param1_1_0: 3
+  module1_param1_1_1: 4
+  module1_param1_2_0: 5
+  module1_param1_2_1: 6
+  module1_param2_0: 7
+  module1_param2_1: 8
+  module2_param1_0_0: 1
+  module2_param1_0_1: 2
+  module2_param1_1_0: 3
+  module2_param1_1_1: 4
+  module2_param1_2_0: 5
+  module2_param1_2_1: 6
+  module2_param2_0: 7
+  module2_param2_1: 8
 expected_outputs:
-  module1_param1_0_0:
-    SecretInteger: '1'
-  module1_param1_0_1:
-    SecretInteger: '2'
-  module1_param1_1_0:
-    SecretInteger: '3'
-  module1_param1_1_1:
-    SecretInteger: '4'
-  module1_param1_2_0:
-    SecretInteger: '5'
-  module1_param1_2_1:
-    SecretInteger: '6'
-  module1_param2_0:
-    SecretInteger: '7'
-  module1_param2_1:
-    SecretInteger: '8'
-  module2_param1_0_0:
-    Integer: '1'
-  module2_param1_0_1:
-    Integer: '2'
-  module2_param1_1_0:
-    Integer: '3'
-  module2_param1_1_1:
-    Integer: '4'
-  module2_param1_2_0:
-    Integer: '5'
-  module2_param1_2_1:
-    Integer: '6'
-  module2_param2_0:
-    Integer: '7'
-  module2_param2_1:
-    Integer: '8'
+  module1_param1_0_0: 1
+  module1_param1_0_1: 2
+  module1_param1_1_0: 3
+  module1_param1_1_1: 4
+  module1_param1_2_0: 5
+  module1_param1_2_1: 6
+  module1_param2_0: 7
+  module1_param2_1: 8
+  module2_param1_0_0: 1
+  module2_param1_0_1: 2
+  module2_param1_1_0: 3
+  module2_param1_1_1: 4
+  module2_param1_2_0: 5
+  module2_param1_2_1: 6
+  module2_param2_0: 7
+  module2_param2_1: 8

--- a/tests/nada-tests/tests/logistic_regression.yaml
+++ b/tests/nada-tests/tests/logistic_regression.yaml
@@ -1,47 +1,25 @@
 program: logistic_regression
 inputs:
-  testmod_coef_1_2:
-    SecretInteger: '3'
-  testmod_intercept_2:
-    SecretInteger: '3'
-  testmod_coef_1_1:
-    SecretInteger: '3'
-  testmod_coef_0_0:
-    SecretInteger: '3'
-  input_1:
-    SecretInteger: '3'
-  testmod_coef_2_1:
-    SecretInteger: '3'
-  testmod_coef_1_0:
-    SecretInteger: '3'
-  testmod_coef_1_3:
-    SecretInteger: '3'
-  testmod_coef_0_2:
-    SecretInteger: '3'
-  input_3:
-    SecretInteger: '3'
-  testmod_intercept_0:
-    SecretInteger: '3'
-  testmod_coef_2_2:
-    SecretInteger: '3'
-  testmod_coef_0_3:
-    SecretInteger: '3'
-  input_2:
-    SecretInteger: '3'
-  testmod_coef_2_3:
-    SecretInteger: '3'
-  testmod_coef_0_1:
-    SecretInteger: '3'
-  testmod_intercept_1:
-    SecretInteger: '3'
-  input_0:
-    SecretInteger: '3'
-  testmod_coef_2_0:
-    SecretInteger: '3'
+  testmod_coef_1_2: 3
+  testmod_intercept_2: 3
+  testmod_coef_1_1: 3
+  testmod_coef_0_0: 3
+  input_1: 3
+  testmod_coef_2_1: 3
+  testmod_coef_1_0: 3
+  testmod_coef_1_3: 3
+  testmod_coef_0_2: 3
+  input_3: 3
+  testmod_intercept_0: 3
+  testmod_coef_2_2: 3
+  testmod_coef_0_3: 3
+  input_2: 3
+  testmod_coef_2_3: 3
+  testmod_coef_0_1: 3
+  testmod_intercept_1: 3
+  input_0: 3
+  testmod_coef_2_0: 3
 expected_outputs:
-  my_output_0:
-    SecretInteger: '39'
-  my_output_1:
-    SecretInteger: '39'
-  my_output_2:
-    SecretInteger: '39'
+  my_output_0: 39
+  my_output_1: 39
+  my_output_2: 39

--- a/tests/nada-tests/tests/nested_modules.yaml
+++ b/tests/nada-tests/tests/nested_modules.yaml
@@ -1,37 +1,20 @@
 program: nested_modules
 inputs:
-  input_0:
-    SecretInteger: '1'
-  input_1:
-    SecretInteger: '2'
-  testmod_mod.param1_0_0:
-    SecretInteger: '1'
-  testmod_mod.param1_0_1:
-    SecretInteger: '2'
-  testmod_mod.param1_1_0:
-    SecretInteger: '3'
-  testmod_mod.param1_1_1:
-    SecretInteger: '4'
-  testmod_mod.param1_2_0:
-    SecretInteger: '5'
-  testmod_mod.param1_2_1:
-    SecretInteger: '6'
-  testmod_mod.param2_0:
-    SecretInteger: '7'
-  testmod_mod.param2_1:
-    SecretInteger: '8'
-  testmod_mod.param2_2:
-    SecretInteger: '9'
-  testmod_param1_0:
-    SecretInteger: '1'
-  testmod_param1_1:
-    SecretInteger: '2'
-  testmod_param1_2:
-    SecretInteger: '3'
+  input_0: 1
+  input_1: 2
+  testmod_mod.param1_0_0: 1
+  testmod_mod.param1_0_1: 2
+  testmod_mod.param1_1_0: 3
+  testmod_mod.param1_1_1: 4
+  testmod_mod.param1_2_0: 5
+  testmod_mod.param1_2_1: 6
+  testmod_mod.param2_0: 7
+  testmod_mod.param2_1: 8
+  testmod_mod.param2_2: 9
+  testmod_param1_0: 1
+  testmod_param1_1: 2
+  testmod_param1_2: 3
 expected_outputs:
-  output_0:
-    SecretInteger: '8'
-  output_1:
-    SecretInteger: '10'
-  output_2:
-    SecretInteger: '12'
+  output_0: 8
+  output_1: 10
+  output_2: 12

--- a/tests/nada-tests/tests/parameters.yaml
+++ b/tests/nada-tests/tests/parameters.yaml
@@ -1,31 +1,17 @@
 program: parameters
 inputs:
-  input_0:
-    SecretInteger: '1'
-  input_1:
-    SecretInteger: '2'
-  testmod_param1_0_0:
-    SecretInteger: '1'
-  testmod_param1_0_1:
-    SecretInteger: '2'
-  testmod_param1_1_0:
-    SecretInteger: '3'
-  testmod_param1_1_1:
-    SecretInteger: '4'
-  testmod_param1_2_0:
-    SecretInteger: '5'
-  testmod_param1_2_1:
-    SecretInteger: '6'
-  testmod_param2_0:
-    SecretInteger: '7'
-  testmod_param2_1:
-    SecretInteger: '8'
-  testmod_param2_2:
-    SecretInteger: '9'
+  input_0: 1
+  input_1: 2
+  testmod_param1_0_0: 1
+  testmod_param1_0_1: 2
+  testmod_param1_1_0: 3
+  testmod_param1_1_1: 4
+  testmod_param1_2_0: 5
+  testmod_param1_2_1: 6
+  testmod_param2_0: 7
+  testmod_param2_1: 8
+  testmod_param2_2: 9
 expected_outputs:
-  output_0:
-    SecretInteger: '7'
-  output_1:
-    SecretInteger: '8'
-  output_2:
-    SecretInteger: '9'
+  output_0: 7
+  output_1: 8
+  output_2: 9

--- a/tests/nada-tests/tests/pool.yaml
+++ b/tests/nada-tests/tests/pool.yaml
@@ -1,275 +1,139 @@
 program: pool
 inputs:
-  input_x_0_0_0_0:
-    SecretInteger: '4'
-  input_x_0_2_0_0:
-    SecretInteger: '4'
-  input_x_0_3_1_0:
-    SecretInteger: '4'
-  input_x_0_2_2_1:
-    SecretInteger: '4'
-  input_x_0_1_2_0:
-    SecretInteger: '4'
-  input_x_0_1_0_1:
-    SecretInteger: '4'
-  input_x_0_1_1_1:
-    SecretInteger: '4'
-  input_x_0_1_2_1:
-    SecretInteger: '4'
-  input_x_0_2_0_1:
-    SecretInteger: '4'
-  input_x_0_2_1_1:
-    SecretInteger: '4'
-  input_x_0_0_2_1:
-    SecretInteger: '4'
-  input_x_0_0_1_0:
-    SecretInteger: '4'
-  input_x_0_2_3_0:
-    SecretInteger: '4'
-  input_x_0_3_3_1:
-    SecretInteger: '4'
-  input_x_0_2_3_1:
-    SecretInteger: '4'
-  input_x_0_2_2_0:
-    SecretInteger: '4'
-  input_x_0_0_3_1:
-    SecretInteger: '4'
-  input_x_0_1_3_0:
-    SecretInteger: '4'
-  input_x_0_3_3_0:
-    SecretInteger: '4'
-  input_x_0_2_1_0:
-    SecretInteger: '4'
-  input_x_0_0_2_0:
-    SecretInteger: '4'
-  input_x_0_0_3_0:
-    SecretInteger: '4'
-  input_x_0_1_3_1:
-    SecretInteger: '4'
-  input_x_0_0_0_1:
-    SecretInteger: '4'
-  input_x_0_1_1_0:
-    SecretInteger: '4'
-  input_x_0_1_0_0:
-    SecretInteger: '4'
-  input_x_0_3_2_0:
-    SecretInteger: '4'
-  input_x_0_3_0_1:
-    SecretInteger: '4'
-  input_x_0_3_0_0:
-    SecretInteger: '4'
-  input_x_0_3_2_1:
-    SecretInteger: '4'
-  input_x_0_3_1_1:
-    SecretInteger: '4'
-  input_x_0_0_1_1:
-    SecretInteger: '4'
-  input_y_0_0_0:
-    SecretInteger: '4'
-  input_y_2_0_0:
-    SecretInteger: '4'
-  input_y_3_1_0:
-    SecretInteger: '4'
-  input_y_2_2_1:
-    SecretInteger: '4'
-  input_y_1_2_0:
-    SecretInteger: '4'
-  input_y_1_0_1:
-    SecretInteger: '4'
-  input_y_1_1_1:
-    SecretInteger: '4'
-  input_y_1_2_1:
-    SecretInteger: '4'
-  input_y_2_0_1:
-    SecretInteger: '4'
-  input_y_2_1_1:
-    SecretInteger: '4'
-  input_y_0_2_1:
-    SecretInteger: '4'
-  input_y_0_1_0:
-    SecretInteger: '4'
-  input_y_2_3_0:
-    SecretInteger: '4'
-  input_y_3_3_1:
-    SecretInteger: '4'
-  input_y_2_3_1:
-    SecretInteger: '4'
-  input_y_2_2_0:
-    SecretInteger: '4'
-  input_y_0_3_1:
-    SecretInteger: '4'
-  input_y_1_3_0:
-    SecretInteger: '4'
-  input_y_3_3_0:
-    SecretInteger: '4'
-  input_y_2_1_0:
-    SecretInteger: '4'
-  input_y_0_2_0:
-    SecretInteger: '4'
-  input_y_0_3_0:
-    SecretInteger: '4'
-  input_y_1_3_1:
-    SecretInteger: '4'
-  input_y_0_0_1:
-    SecretInteger: '4'
-  input_y_1_1_0:
-    SecretInteger: '4'
-  input_y_1_0_0:
-    SecretInteger: '4'
-  input_y_3_2_0:
-    SecretInteger: '4'
-  input_y_3_0_1:
-    SecretInteger: '4'
-  input_y_3_0_0:
-    SecretInteger: '4'
-  input_y_3_2_1:
-    SecretInteger: '4'
-  input_y_3_1_1:
-    SecretInteger: '4'
-  input_y_0_1_1:
-    SecretInteger: '4'
+  input_x_0_0_0_0: 4
+  input_x_0_2_0_0: 4
+  input_x_0_3_1_0: 4
+  input_x_0_2_2_1: 4
+  input_x_0_1_2_0: 4
+  input_x_0_1_0_1: 4
+  input_x_0_1_1_1: 4
+  input_x_0_1_2_1: 4
+  input_x_0_2_0_1: 4
+  input_x_0_2_1_1: 4
+  input_x_0_0_2_1: 4
+  input_x_0_0_1_0: 4
+  input_x_0_2_3_0: 4
+  input_x_0_3_3_1: 4
+  input_x_0_2_3_1: 4
+  input_x_0_2_2_0: 4
+  input_x_0_0_3_1: 4
+  input_x_0_1_3_0: 4
+  input_x_0_3_3_0: 4
+  input_x_0_2_1_0: 4
+  input_x_0_0_2_0: 4
+  input_x_0_0_3_0: 4
+  input_x_0_1_3_1: 4
+  input_x_0_0_0_1: 4
+  input_x_0_1_1_0: 4
+  input_x_0_1_0_0: 4
+  input_x_0_3_2_0: 4
+  input_x_0_3_0_1: 4
+  input_x_0_3_0_0: 4
+  input_x_0_3_2_1: 4
+  input_x_0_3_1_1: 4
+  input_x_0_0_1_1: 4
+  input_y_0_0_0: 4
+  input_y_2_0_0: 4
+  input_y_3_1_0: 4
+  input_y_2_2_1: 4
+  input_y_1_2_0: 4
+  input_y_1_0_1: 4
+  input_y_1_1_1: 4
+  input_y_1_2_1: 4
+  input_y_2_0_1: 4
+  input_y_2_1_1: 4
+  input_y_0_2_1: 4
+  input_y_0_1_0: 4
+  input_y_2_3_0: 4
+  input_y_3_3_1: 4
+  input_y_2_3_1: 4
+  input_y_2_2_0: 4
+  input_y_0_3_1: 4
+  input_y_1_3_0: 4
+  input_y_3_3_0: 4
+  input_y_2_1_0: 4
+  input_y_0_2_0: 4
+  input_y_0_3_0: 4
+  input_y_1_3_1: 4
+  input_y_0_0_1: 4
+  input_y_1_1_0: 4
+  input_y_1_0_0: 4
+  input_y_3_2_0: 4
+  input_y_3_0_1: 4
+  input_y_3_0_0: 4
+  input_y_3_2_1: 4
+  input_y_3_1_1: 4
+  input_y_0_1_1: 4
 expected_outputs:
-  x_pool2_0_2_1_1:
-    SecretInteger: '2'
-  x_pool2_0_1_2_0:
-    SecretInteger: '1'
-  x_pool2_0_3_2_1:
-    SecretInteger: '1'
-  x_pool1_0_2_1_0:
-    SecretInteger: '4'
-  x_pool1_0_3_0_0:
-    SecretInteger: '4'
-  x_pool1_0_1_1_0:
-    SecretInteger: '4'
-  x_pool2_0_3_0_0:
-    SecretInteger: '1'
-  x_pool2_0_3_1_1:
-    SecretInteger: '2'
-  x_pool1_0_3_2_0:
-    SecretInteger: '4'
-  x_pool1_0_0_1_0:
-    SecretInteger: '4'
-  x_pool1_0_3_1_0:
-    SecretInteger: '4'
-  x_pool2_0_2_1_0:
-    SecretInteger: '2'
-  x_pool1_0_0_0_0:
-    SecretInteger: '4'
-  x_pool2_0_1_0_1:
-    SecretInteger: '1'
-  x_pool2_0_1_0_0:
-    SecretInteger: '1'
-  x_pool2_0_2_2_1:
-    SecretInteger: '1'
-  x_pool2_0_0_2_1:
-    SecretInteger: '1'
-  x_pool2_0_0_0_0:
-    SecretInteger: '1'
-  x_pool2_0_1_1_1:
-    SecretInteger: '2'
-  x_pool1_0_0_2_0:
-    SecretInteger: '4'
-  x_pool2_0_3_2_0:
-    SecretInteger: '1'
-  x_pool1_0_1_2_0:
-    SecretInteger: '4'
-  x_pool1_0_2_0_0:
-    SecretInteger: '4'
-  x_pool2_0_0_1_0:
-    SecretInteger: '2'
-  x_pool2_0_3_1_0:
-    SecretInteger: '2'
-  x_pool2_0_1_2_1:
-    SecretInteger: '1'
-  x_pool2_0_1_1_0:
-    SecretInteger: '2'
-  x_pool2_0_2_2_0:
-    SecretInteger: '1'
-  x_pool2_0_2_0_1:
-    SecretInteger: '1'
-  x_pool1_0_1_0_0:
-    SecretInteger: '4'
-  x_pool2_0_3_0_1:
-    SecretInteger: '1'
-  x_pool1_0_2_2_0:
-    SecretInteger: '4'
-  x_pool2_0_0_1_1:
-    SecretInteger: '2'
-  x_pool2_0_0_0_1:
-    SecretInteger: '1'
-  x_pool2_0_0_2_0:
-    SecretInteger: '1'
-  x_pool2_0_2_0_0:
-    SecretInteger: '1'
-  y_pool2_2_1_1:
-    SecretInteger: '2'
-  y_pool2_1_2_0:
-    SecretInteger: '1'
-  y_pool2_3_2_1:
-    SecretInteger: '1'
-  y_pool1_2_1_0:
-    SecretInteger: '4'
-  y_pool1_3_0_0:
-    SecretInteger: '4'
-  y_pool1_1_1_0:
-    SecretInteger: '4'
-  y_pool2_3_0_0:
-    SecretInteger: '1'
-  y_pool2_3_1_1:
-    SecretInteger: '2'
-  y_pool1_3_2_0:
-    SecretInteger: '4'
-  y_pool1_0_1_0:
-    SecretInteger: '4'
-  y_pool1_3_1_0:
-    SecretInteger: '4'
-  y_pool2_2_1_0:
-    SecretInteger: '2'
-  y_pool1_0_0_0:
-    SecretInteger: '4'
-  y_pool2_1_0_1:
-    SecretInteger: '1'
-  y_pool2_1_0_0:
-    SecretInteger: '1'
-  y_pool2_2_2_1:
-    SecretInteger: '1'
-  y_pool2_0_2_1:
-    SecretInteger: '1'
-  y_pool2_0_0_0:
-    SecretInteger: '1'
-  y_pool2_1_1_1:
-    SecretInteger: '2'
-  y_pool1_0_2_0:
-    SecretInteger: '4'
-  y_pool2_3_2_0:
-    SecretInteger: '1'
-  y_pool1_1_2_0:
-    SecretInteger: '4'
-  y_pool1_2_0_0:
-    SecretInteger: '4'
-  y_pool2_0_1_0:
-    SecretInteger: '2'
-  y_pool2_3_1_0:
-    SecretInteger: '2'
-  y_pool2_1_2_1:
-    SecretInteger: '1'
-  y_pool2_1_1_0:
-    SecretInteger: '2'
-  y_pool2_2_2_0:
-    SecretInteger: '1'
-  y_pool2_2_0_1:
-    SecretInteger: '1'
-  y_pool1_1_0_0:
-    SecretInteger: '4'
-  y_pool2_3_0_1:
-    SecretInteger: '1'
-  y_pool1_2_2_0:
-    SecretInteger: '4'
-  y_pool2_0_1_1:
-    SecretInteger: '2'
-  y_pool2_0_0_1:
-    SecretInteger: '1'
-  y_pool2_0_2_0:
-    SecretInteger: '1'
-  y_pool2_2_0_0:
-    SecretInteger: '1'
+  x_pool2_0_2_1_1: 2
+  x_pool2_0_1_2_0: 1
+  x_pool2_0_3_2_1: 1
+  x_pool1_0_2_1_0: 4
+  x_pool1_0_3_0_0: 4
+  x_pool1_0_1_1_0: 4
+  x_pool2_0_3_0_0: 1
+  x_pool2_0_3_1_1: 2
+  x_pool1_0_3_2_0: 4
+  x_pool1_0_0_1_0: 4
+  x_pool1_0_3_1_0: 4
+  x_pool2_0_2_1_0: 2
+  x_pool1_0_0_0_0: 4
+  x_pool2_0_1_0_1: 1
+  x_pool2_0_1_0_0: 1
+  x_pool2_0_2_2_1: 1
+  x_pool2_0_0_2_1: 1
+  x_pool2_0_0_0_0: 1
+  x_pool2_0_1_1_1: 2
+  x_pool1_0_0_2_0: 4
+  x_pool2_0_3_2_0: 1
+  x_pool1_0_1_2_0: 4
+  x_pool1_0_2_0_0: 4
+  x_pool2_0_0_1_0: 2
+  x_pool2_0_3_1_0: 2
+  x_pool2_0_1_2_1: 1
+  x_pool2_0_1_1_0: 2
+  x_pool2_0_2_2_0: 1
+  x_pool2_0_2_0_1: 1
+  x_pool1_0_1_0_0: 4
+  x_pool2_0_3_0_1: 1
+  x_pool1_0_2_2_0: 4
+  x_pool2_0_0_1_1: 2
+  x_pool2_0_0_0_1: 1
+  x_pool2_0_0_2_0: 1
+  x_pool2_0_2_0_0: 1
+  y_pool2_2_1_1: 2
+  y_pool2_1_2_0: 1
+  y_pool2_3_2_1: 1
+  y_pool1_2_1_0: 4
+  y_pool1_3_0_0: 4
+  y_pool1_1_1_0: 4
+  y_pool2_3_0_0: 1
+  y_pool2_3_1_1: 2
+  y_pool1_3_2_0: 4
+  y_pool1_0_1_0: 4
+  y_pool1_3_1_0: 4
+  y_pool2_2_1_0: 2
+  y_pool1_0_0_0: 4
+  y_pool2_1_0_1: 1
+  y_pool2_1_0_0: 1
+  y_pool2_2_2_1: 1
+  y_pool2_0_2_1: 1
+  y_pool2_0_0_0: 1
+  y_pool2_1_1_1: 2
+  y_pool1_0_2_0: 4
+  y_pool2_3_2_0: 1
+  y_pool1_1_2_0: 4
+  y_pool1_2_0_0: 4
+  y_pool2_0_1_0: 2
+  y_pool2_3_1_0: 2
+  y_pool2_1_2_1: 1
+  y_pool2_1_1_0: 2
+  y_pool2_2_2_0: 1
+  y_pool2_2_0_1: 1
+  y_pool1_1_0_0: 4
+  y_pool2_3_0_1: 1
+  y_pool1_2_2_0: 4
+  y_pool2_0_1_1: 2
+  y_pool2_0_0_1: 1
+  y_pool2_0_2_0: 1
+  y_pool2_2_0_0: 1

--- a/tests/nada-tests/tests/prophet.yaml
+++ b/tests/nada-tests/tests/prophet.yaml
@@ -1,53 +1,28 @@
 program: prophet
 inputs:
-  my_prophet_m_0_0:
-    SecretInteger: '3'
-  my_prophet_beta_0_4:
-    SecretInteger: '3'
-  my_prophet_beta_0_5:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_1:
-    SecretInteger: '3'
-  my_prophet_delta_0_1:
-    SecretInteger: '3'
-  my_prophet_y_scale_0:
-    SecretInteger: '3'
-  floor_2:
-    SecretInteger: '3'
-  my_prophet_delta_0_0:
-    SecretInteger: '3'
-  floor_3:
-    SecretInteger: '3'
-  t_2:
-    SecretInteger: '3'
-  floor_0:
-    SecretInteger: '3'
-  my_prophet_changepoints_t_0:
-    SecretInteger: '3'
-  my_prophet_beta_0_1:
-    SecretInteger: '3'
-  t_1:
-    SecretInteger: '3'
-  my_prophet_beta_0_3:
-    SecretInteger: '3'
-  my_prophet_k_0_0:
-    SecretInteger: '3'
-  my_prophet_beta_0_2:
-    SecretInteger: '3'
-  floor_1:
-    SecretInteger: '3'
-  t_0:
-    SecretInteger: '3'
-  t_3:
-    SecretInteger: '3'
-  my_prophet_beta_0_0:
-    SecretInteger: '3'
+  my_prophet_m_0_0: 3
+  my_prophet_beta_0_4: 3
+  my_prophet_beta_0_5: 3
+  my_prophet_changepoints_t_1: 3
+  my_prophet_delta_0_1: 3
+  my_prophet_y_scale_0: 3
+  floor_2: 3
+  my_prophet_delta_0_0: 3
+  floor_3: 3
+  t_2: 3
+  floor_0: 3
+  my_prophet_changepoints_t_0: 3
+  my_prophet_beta_0_1: 3
+  t_1: 3
+  my_prophet_beta_0_3: 3
+  my_prophet_k_0_0: 3
+  my_prophet_beta_0_2: 3
+  floor_1: 3
+  t_0: 3
+  t_3: 3
+  my_prophet_beta_0_0: 3
 expected_outputs:
-  forecast_2:
-    SecretInteger: '3'
-  forecast_0:
-    SecretInteger: '3'
-  forecast_3:
-    SecretInteger: '3'
-  forecast_1:
-    SecretInteger: '2'
+  forecast_2: 3
+  forecast_0: 3
+  forecast_3: 3
+  forecast_1: 2

--- a/tests/test_all_nada.py
+++ b/tests/test_all_nada.py
@@ -60,23 +60,10 @@ class TestSuite:
 
     def test_build(self, testname):
         # Get current working directory
-        cwd = os.getcwd()
-        try:
-            # Build Nada Program
-            build_nada(testname)
-        finally:
-            # Return to initial directory
-            os.chdir(cwd)
+        build_nada(testname)
 
     def test_run(self, testname):
-        # Get current working directory
-        cwd = os.getcwd()
-        try:
-            # Build Nada Program
-            build_nada(testname)
-        finally:
-            # Return to initial directory
-            os.chdir(cwd)
+        run_nada(testname)
 
 
 def test_client():


### PR DESCRIPTION
This PR includes the changes required to update Nada-AI to version 0.5.0 corresponding to version 0.6.0 of Nada-DSL and Nillion Python Client.

Note: This is expected to fail before finishing we need to:
- [x] Version 0.6.0 of Nada DSL and Python Client needs to be released.
- [x] Nada Numpy version 0.5.0 needs to be released before.
- [x] Update poetry lock: `poetry lock`
- [x] Push to and wait for CI/CD to execute.